### PR TITLE
Call flag.Parse() in init()

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -20,6 +20,7 @@ var (
 
 // Setup clients and servers.
 func init() {
+	flag.Parse()
 	client = &http.Transport{
 		ResponseHeaderTimeout: requestTimeout,
 	}


### PR DESCRIPTION
We were relying on `go test` doing this for us but this means that all flag
vars get their default values and can't be overridden from the CLI. By
calling Parse() they are populated correctly. Sorry @mikepea ;)
