### PR TITLE
Test for 'Origin by default', plus supporting tests & flags

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"log"
 	"net/http"
 	"testing"
 	"time"
@@ -35,12 +36,17 @@ func init() {
 		TLSClientConfig:       tlsOptions,
 	}
 	originServer = StartServer(*originPort)
+
+	log.Println("Confirming that CDN has successfully probed Origin")
+	err := confirmOriginIsEnabled(originServer, *edgeHost)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func TestHelpers(t *testing.T) {
 	testHelpersCDNServeMuxHandlers(t, originServer)
 	testHelpersCDNServeMuxProbes(t, originServer)
-	testOriginIsEnabled(t, originServer, *edgeHost)
 }
 
 // Should redirect from HTTP to HTTPS without hitting origin.

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -25,12 +25,9 @@ func init() {
 
 	flag.Parse()
 
-	var tlsOptions *tls.Config
-
-	if *insecureTLS == true {
-		tlsOptions = &tls.Config{InsecureSkipVerify: true}
-	} else {
-		tlsOptions = &tls.Config{}
+	tlsOptions := &tls.Config{}
+	if *insecureTLS {
+		tlsOptions.InsecureSkipVerify = true
 	}
 
 	client = &http.Transport{

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -87,7 +87,7 @@ func TestRequestsGoToOriginByDefault(t *testing.T) {
 		t.Errorf("Status code expected 200, got %d", resp.StatusCode)
 	}
 	if d := resp.Header.Get("EnsureOriginServed"); d != uuid {
-		t.Errorf("EnsureOriginServed header has not come from Origin: expected %s, got %s", uuid, d)
+		t.Errorf("EnsureOriginServed header has not come from Origin: expected %q, got %q", uuid, d)
 	}
 
 }

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -68,6 +68,35 @@ func TestProtocolRedirect(t *testing.T) {
 	}
 }
 
+func TestOriginIsEnabled(t *testing.T) {
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	retries := 0
+	maxRetries := 10
+	var sourceUrl string
+	for retries <= maxRetries {
+		uuid := NewUUID()
+		sourceUrl = fmt.Sprintf("https://%s/confirm-cdn-ok-%s", *edgeHost, uuid)
+		req, _ := http.NewRequest("GET", sourceUrl, nil)
+		resp, err := client.RoundTrip(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		retries++
+		time.Sleep(5 * time.Second)
+		if resp.StatusCode == 200 {
+			break
+		}
+	}
+
+	if retries == maxRetries {
+		t.Errorf("CDN still not available after %n attempts", retries)
+	}
+
+}
+
 // Should send request to origin by default
 func TestRequestsGoToOriginByDefault(t *testing.T) {
 	t.Error("Not implemented")

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -11,8 +12,9 @@ import (
 const requestTimeout = time.Second * 5
 
 var (
-	edgeHost   = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
-	originPort = flag.Int("originPort", 8080, "Origin port to listen on for requests")
+	edgeHost    = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
+	originPort  = flag.Int("originPort", 8080, "Origin port to listen on for requests")
+	insecureTLS = flag.Bool("insecureTLS", false, "Whether to check server certificates")
 
 	client       *http.Transport
 	originServer *CDNServeMux
@@ -20,9 +22,20 @@ var (
 
 // Setup clients and servers.
 func init() {
+
 	flag.Parse()
+
+	var tlsOptions *tls.Config
+
+	if *insecureTLS == true {
+		tlsOptions = &tls.Config{InsecureSkipVerify: true}
+	} else {
+		tlsOptions = &tls.Config{}
+	}
+
 	client = &http.Transport{
 		ResponseHeaderTimeout: requestTimeout,
+		TLSClientConfig:       tlsOptions,
 	}
 	originServer = StartServer(*originPort)
 }

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -99,7 +99,28 @@ func TestOriginIsEnabled(t *testing.T) {
 
 // Should send request to origin by default
 func TestRequestsGoToOriginByDefault(t *testing.T) {
-	t.Error("Not implemented")
+	uuid := NewUUID()
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == fmt.Sprintf("/test-origin/%s", uuid) {
+			w.Header().Set("EnsureOriginServed", uuid)
+		}
+	})
+
+	sourceUrl := fmt.Sprintf("https://%s/test-origin/%s", *edgeHost, uuid)
+
+	req, _ := http.NewRequest("GET", sourceUrl, nil)
+	resp, err := client.RoundTrip(req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Status code expected 200, got %d", resp.StatusCode)
+	}
+	if d := resp.Header.Get("EnsureOriginServed"); d != uuid {
+		t.Errorf("EnsureOriginServed header has not come from Origin: expected %s, got %s", uuid, d)
+	}
+
 }
 
 // Should return 403 for PURGE requests from IPs not in the whitelist.

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -70,12 +70,12 @@ func TestProtocolRedirect(t *testing.T) {
 func TestRequestsGoToOriginByDefault(t *testing.T) {
 	uuid := NewUUID()
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == fmt.Sprintf("/test-origin/%s", uuid) {
+		if r.Method == "GET" && r.URL.Path == fmt.Sprintf("/%s", uuid) {
 			w.Header().Set("EnsureOriginServed", uuid)
 		}
 	})
 
-	sourceUrl := fmt.Sprintf("https://%s/test-origin/%s", *edgeHost, uuid)
+	sourceUrl := fmt.Sprintf("https://%s/%s", *edgeHost, uuid)
 
 	req, _ := http.NewRequest("GET", sourceUrl, nil)
 	resp, err := client.RoundTrip(req)

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -40,7 +40,7 @@ func init() {
 func TestHelpers(t *testing.T) {
 	testHelpersCDNServeMuxHandlers(t, originServer)
 	testHelpersCDNServeMuxProbes(t, originServer)
-	testOriginIsEnabled(t, originServer, edgeHost)
+	testOriginIsEnabled(t, originServer, *edgeHost)
 }
 
 // Should redirect from HTTP to HTTPS without hitting origin.

--- a/helpers.go
+++ b/helpers.go
@@ -105,7 +105,7 @@ func testHelpersCDNServeMuxProbes(t *testing.T, mux *CDNServeMux) {
 	}
 }
 
-func testOriginIsEnabled(t *testing.T, mux *CDNServeMux, edgeHost *string) {
+func testOriginIsEnabled(t *testing.T, mux *CDNServeMux, edgeHost string) {
 	mux.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
@@ -116,7 +116,7 @@ func testOriginIsEnabled(t *testing.T, mux *CDNServeMux, edgeHost *string) {
 
 	for try := 0; try <= maxRetries; try++ {
 		uuid := NewUUID()
-		sourceUrl = fmt.Sprintf("https://%s/confirm-cdn-ok-%s", *edgeHost, uuid)
+		sourceUrl = fmt.Sprintf("https://%s/confirm-cdn-ok-%s", edgeHost, uuid)
 		req, _ := http.NewRequest("GET", sourceUrl, nil)
 		resp, err := client.RoundTrip(req)
 		if err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -105,7 +105,7 @@ func testHelpersCDNServeMuxProbes(t *testing.T, mux *CDNServeMux) {
 	}
 }
 
-func testOriginIsEnabled(t *testing.T, mux *CDNServeMux, edgeHost string) {
+func confirmOriginIsEnabled(mux *CDNServeMux, edgeHost string) error {
 	mux.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
@@ -120,17 +120,17 @@ func testOriginIsEnabled(t *testing.T, mux *CDNServeMux, edgeHost string) {
 		req, _ := http.NewRequest("GET", sourceUrl, nil)
 		resp, err := client.RoundTrip(req)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 		if resp.StatusCode == 200 {
 			time.Sleep(timeBetweenAttempts) // wait for other CDN nodes to catch up
 			break
 		}
 		if try == maxRetries {
-			t.Errorf("CDN still not available after %n attempts", maxRetries)
-			break
+			return fmt.Errorf("CDN still not available after %n attempts", maxRetries)
 		}
 		time.Sleep(timeBetweenAttempts)
 	}
+	return nil // all good!
 
 }


### PR DESCRIPTION
- Add an '-insecureTLS' option, to disable cert checking
- Add a test to poll the CDN until it has successfully probed Origin 
- Add test code to check that a request will go to origin 'by default' (as in, not in the cache)
