### PR TITLE
Implement test for PURGE returning 403

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -140,9 +140,25 @@ func TestFirstResponseCached(t *testing.T) {
 	}
 }
 
-// Should return 403 for PURGE requests from IPs not in the whitelist.
+// Should return 403 for PURGE requests from IPs not in the whitelist. We
+// assume that this is not running from a whitelisted address.
 func TestRestrictPurgeRequests(t *testing.T) {
-	t.Error("Not implemented")
+	const expectedStatusCode = 403
+
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Request should not have made it to origin")
+	})
+
+	url := fmt.Sprintf("https://%s/", *edgeHost)
+	req, _ := http.NewRequest("PURGE", url, nil)
+
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != expectedStatusCode {
+		t.Errorf("Incorrect status code. Expected %d, got %d", expectedStatusCode, resp.StatusCode)
+	}
 }
 
 // Should create an X-Forwarded-For header containing the client's IP.


### PR DESCRIPTION
This test, rather excitingly, proves that the behaviour has changed since we
implemented it in: https://www.pivotaltracker.com/story/show/62136616

The CDN now returns 200 and the body of a normal GET request. I suspect that
it's something to do with the `req.request = GET` hack that they suggested
implementing.

We should merge this but separately fix the config to make this test pass.
