### PR TITLE
Test that for X-Served-By is set by Edge

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -251,16 +251,10 @@ func TestXServedByHeaderContainsFastlyNodeIdAndLocation(t *testing.T) {
 
 	expectedFastlyXServedByRegexp := regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
 
-	uuid := NewUUID()
-	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == fmt.Sprintf("/%s", uuid) {
-			w.WriteHeader(200)
-		}
-	})
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
 
-	sourceUrl := fmt.Sprintf("https://%s/%s", *edgeHost, uuid)
+	sourceUrl := fmt.Sprintf("https://%s/", *edgeHost)
 
-	// Get first request, will come from origin. Edge Hit Count 0
 	req, _ := http.NewRequest("GET", sourceUrl, nil)
 	resp, err := client.RoundTrip(req)
 	if err != nil {

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -246,8 +246,10 @@ func TestXCacheHeaderContainsHitMissFromBothProviderAndOrigin(t *testing.T) {
 	t.Error("Not implemented")
 }
 
-// Should set an X-Served-By header giving information on the node and location served from.
-func TestXServedByHeaderContainsANodeIdAndLocation(t *testing.T) {
+// Should set an X-Served-By header giving information on the (Fastly) node and location served from.
+func TestXServedByHeaderContainsFastlyNodeIdAndLocation(t *testing.T) {
+
+	expectedFastlyXServedByRegexp := regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
 
 	uuid := NewUUID()
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
@@ -270,8 +272,7 @@ func TestXServedByHeaderContainsANodeIdAndLocation(t *testing.T) {
 		t.Error("X-Served-By header has not been set by Edge")
 	}
 
-	re := regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
-	if re.FindString(actualHeader) != actualHeader {
+	if expectedFastlyXServedByRegexp.FindString(actualHeader) != actualHeader {
 		t.Errorf("X-Served-By is not as expected: got %q", actualHeader)
 	}
 

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -28,6 +28,14 @@ sub vcl_recv {
 
 sub vcl_deliver {
 
+  # Mock the X-Served-By header behaviour to match Fastly.
+  # NB "cache-wibble-GDS" is a fake server.identity
+  if(!resp.http.X-Served-By) {
+    set resp.http.X-Served-By  = "cache-wibble-GDS";
+  } else {
+    set resp.http.X-Served-By = resp.http.X-Served-By + ", " + "cache-wibble-GDS";
+  }
+
   if(!resp.http.X-Cache-Hits) {
     set resp.http.X-Cache-Hits = obj.hits;
   } else {


### PR DESCRIPTION
We check for the Fastly format of cache-server1234-LOC, which is going
to change between providers, but this at least starts that documentation
going.

Also, check for existance of this header.
