### PR TITLE
Mock CDN in a Vagrant VM using Nginx/Varnish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -37,3 +37,22 @@ To run the tests:
 ```sh
 go test
 ```
+
+## Mock CDN virtual machine
+
+You can use the included Vagrant VM, which runs Nginx and Varnish, to mock
+CDN behaviour. This can be useful when developing new tests or
+functionality, while either offline or in parallel to someone else.
+
+It is unlikely that *all* tests will run successfully. If you want a
+particular test to pass you may need to modify the Nginx or Varnish configs
+in [`mock_cdn_config/`](/mock_cdn_config) accordingly.
+
+To bring up the VM and point the tests at it:
+```
+vagrant up && vagrant provision
+go test -edgeHost 172.16.20.10 -insecureTLS
+```
+
+Please note that this is not a complete substitute for the real thing. You
+**must** test against a real CDN before submitting any pull requests.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.auto_detect = true
+  end
+
+  config.vm.network "private_network", ip: "172.16.20.10"
+
+  config.vm.provision "puppet" do |puppet|
+    puppet.manifest_file = "site.pp"
+    puppet.manifests_path = "mock_cdn_config/manifests"
+    puppet.module_path = "mock_cdn_config/modules"
+  end
+end

--- a/mock_cdn_config/README.md
+++ b/mock_cdn_config/README.md
@@ -1,0 +1,5 @@
+# Mock CDN
+
+Basic set of Puppet modules to configure a Vagrant VM that behaves a bit
+like a CDN. This is optional. See the README in the parent directory for
+usage.

--- a/mock_cdn_config/manifests/site.pp
+++ b/mock_cdn_config/manifests/site.pp
@@ -1,0 +1,4 @@
+$ipaddress_vmhost = regsubst($::ipaddress_eth1, '\.\d+$', '.1')
+
+include varnish
+include nginx

--- a/mock_cdn_config/modules/nginx/manifests/init.pp
+++ b/mock_cdn_config/modules/nginx/manifests/init.pp
@@ -1,0 +1,12 @@
+class nginx {
+  package { ['nginx', 'ssl-cert']:
+    ensure => present,
+  } ->
+  file { '/etc/nginx/sites-enabled/default':
+    ensure  => file,
+    content => template('nginx/default.erb'),
+  } ~>
+  service { 'nginx':
+    ensure => running,
+  }
+}

--- a/mock_cdn_config/modules/nginx/templates/default.erb
+++ b/mock_cdn_config/modules/nginx/templates/default.erb
@@ -2,6 +2,8 @@ server {
   listen 80 default_server;
   location / {
     proxy_pass http://localhost:6081;
+    proxy_redirect default;
+    proxy_redirect https://localhost:6081 https://<%= @ipaddress_eth1 -%>;
   }
 }
 
@@ -11,5 +13,6 @@ server {
   ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
   location / {
     proxy_pass http://localhost:6081;
+    proxy_set_header Fastly-SSL "true";
   }
 }

--- a/mock_cdn_config/modules/nginx/templates/default.erb
+++ b/mock_cdn_config/modules/nginx/templates/default.erb
@@ -1,0 +1,15 @@
+server {
+  listen 80 default_server;
+  location / {
+    proxy_pass http://localhost:6081;
+  }
+}
+
+server {
+  listen 443 default_server ssl;
+  ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+  ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+  location / {
+    proxy_pass http://localhost:6081;
+  }
+}

--- a/mock_cdn_config/modules/varnish/manifests/init.pp
+++ b/mock_cdn_config/modules/varnish/manifests/init.pp
@@ -1,0 +1,12 @@
+class varnish {
+  package { 'varnish':
+    ensure => present,
+  } ->
+  file { '/etc/varnish/default.vcl':
+    ensure  => file,
+    content => template('varnish/default.vcl.erb'),
+  } ~>
+  service { 'varnish':
+    ensure => running,
+  }
+}

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -7,7 +7,18 @@ backend default {
 # functionality you need to test. This shouldn't match our real config
 # line-by-line, otherwise we'll have trouble maintaining parity.
 
+acl purge {
+  "192.168.0.1";
+}
+
 sub vcl_recv {
+  if (req.request == "PURGE") {
+    if (client.ip ~ purge) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -1,0 +1,8 @@
+backend default {
+  .host = "<%= @ipaddress_vmhost -%>";
+  .port = "8080";
+}
+
+# Please add the minimal amount of code required to implement/mimic the
+# functionality you need to test. This shouldn't match our real config
+# line-by-line, otherwise we'll have trouble maintaining parity.

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -6,3 +6,19 @@ backend default {
 # Please add the minimal amount of code required to implement/mimic the
 # functionality you need to test. This shouldn't match our real config
 # line-by-line, otherwise we'll have trouble maintaining parity.
+
+sub vcl_recv {
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+     set obj.status = 301;
+     set obj.response = "Moved Permanently";
+     set obj.http.Location = "https://" + req.http.host + req.url;
+     synthetic {""};
+     return (deliver);
+  }
+}


### PR DESCRIPTION
I found this useful to write and debug new tests while Mike was running
tests against the real service. Some of the behaviour we want to test is
just standard Varnish behaviour. We can mimic some other features with
minimal config changes.

The variable `$::ipaddress_vmhost` contains the IP address of the VM's host
on the other end of the private network - where `go test` would be running.

We'll need to be a careful about breaking this functionality when we
introduced SSL for backends. I'll leave a note in the issue.

---

This is a tidied version of what I was working against yesterday.
