### PR TITLE
Rename insecureTLS to skipVerifyTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ in [`mock_cdn_config/`](/mock_cdn_config) accordingly.
 To bring up the VM and point the tests at it:
 ```
 vagrant up && vagrant provision
-go test -edgeHost 172.16.20.10 -insecureTLS
+go test -edgeHost 172.16.20.10 -skipVerifyTLS
 ```
 
 Please note that this is not a complete substitute for the real thing. You

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -16,7 +16,7 @@ const requestTimeout = time.Second * 5
 var (
 	edgeHost    = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
 	originPort  = flag.Int("originPort", 8080, "Origin port to listen on for requests")
-	insecureTLS = flag.Bool("insecureTLS", false, "Whether to check server certificates")
+	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 
 	client       *http.Transport
 	originServer *CDNServeMux
@@ -28,7 +28,7 @@ func init() {
 	flag.Parse()
 
 	tlsOptions := &tls.Config{}
-	if *insecureTLS {
+	if *skipVerifyTLS {
 		tlsOptions.InsecureSkipVerify = true
 	}
 

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -14,8 +14,8 @@ import (
 const requestTimeout = time.Second * 5
 
 var (
-	edgeHost    = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
-	originPort  = flag.Int("originPort", 8080, "Origin port to listen on for requests")
+	edgeHost      = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
+	originPort    = flag.Int("originPort", 8080, "Origin port to listen on for requests")
 	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 
 	client       *http.Transport


### PR DESCRIPTION
Rename `insecureTLS` to `skipVerifyTLS` to make it clearer what this flag does. Also clarify the flag description.
