### PR TITLE
Implement TestHeaderUnspoofableClientIP() test

### DIFF
--- a/mock_cdn_config/modules/nginx/templates/default.erb
+++ b/mock_cdn_config/modules/nginx/templates/default.erb
@@ -14,5 +14,6 @@ server {
   location / {
     proxy_pass http://localhost:6081;
     proxy_set_header Fastly-SSL "true";
+    proxy_set_header Fastly-Client-IP $remote_addr;
   }
 }

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -22,6 +22,8 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 }
 
 sub vcl_error {


### PR DESCRIPTION
Send a request with a `True-Client-IP` header set to an RFC5737 address and
check that origin receives a request with the header set to a different and
valid IP address (which could be IPv6).

It's important to note that this doesn't check that it's actually _our_ IP
address because:
- For the real CDN we'd have to call out to a third-party service e.g.
  `canhazip.com` to get our external IP.
- For the mock CDN it would be the IP on the private network rather than the
  external IP.

I was concerned that there might be a race condition whereby
`receivedHeaderVal` didn't get set at the point we checked the value. Which
could probably be guarded against by using a channel or reflecting the value
in the response.

However after testing this, by adding some delays to Varnish, I can't
reproduce it. I'm guessing this is because `client.RoundTrip()` blocks until
we get the response (by which time originServer.handler has been called).

PS: `sentHeaderIP` is not a const because slices/arrays cannot be.
