### PR TITLE
Don't print "<nil>" when IP cannot be parsed

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -195,7 +195,7 @@ func TestHeaderUnspoofableClientIP(t *testing.T) {
 
 	receivedHeaderIP := net.ParseIP(receivedHeaderVal)
 	if receivedHeaderIP == nil {
-		t.Fatalf("Origin received %q header with non-IP value %q", headerName, receivedHeaderIP)
+		t.Fatalf("Origin received %q header with non-IP value %q", headerName, receivedHeaderVal)
 	}
 	if receivedHeaderIP.Equal(sentHeaderIP) {
 		t.Errorf("Origin received %q header with unmodified value %q", headerName, receivedHeaderIP)


### PR DESCRIPTION
We only enter this condition when `receivedHeaderIP` is `nil` which results
in the error message saying `with non-IP value "<nil>"`.

Instead print the original unparsed value. So that it's clearer why a
non-empty header value couldn't be validated as an IP address.
