### PR TITLE
Relocate common setup - vars, flags, init()

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -8,11 +8,6 @@ import (
 	"testing"
 )
 
-func TestHelpers(t *testing.T) {
-	testHelpersCDNServeMuxHandlers(t, originServer)
-	testHelpersCDNServeMuxProbes(t, originServer)
-}
-
 // Should redirect from HTTP to HTTPS without hitting origin.
 func TestProtocolRedirect(t *testing.T) {
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -1,50 +1,12 @@
 package main
 
 import (
-	"crypto/tls"
-	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"testing"
-	"time"
 )
-
-const requestTimeout = time.Second * 5
-
-var (
-	edgeHost      = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
-	originPort    = flag.Int("originPort", 8080, "Origin port to listen on for requests")
-	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
-
-	client       *http.Transport
-	originServer *CDNServeMux
-)
-
-// Setup clients and servers.
-func init() {
-
-	flag.Parse()
-
-	tlsOptions := &tls.Config{}
-	if *skipVerifyTLS {
-		tlsOptions.InsecureSkipVerify = true
-	}
-
-	client = &http.Transport{
-		ResponseHeaderTimeout: requestTimeout,
-		TLSClientConfig:       tlsOptions,
-	}
-	originServer = StartServer(*originPort)
-
-	log.Println("Confirming that CDN is healthy")
-	err := confirmEdgeIsHealthy(originServer, *edgeHost)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
 
 func TestHelpers(t *testing.T) {
 	testHelpersCDNServeMuxHandlers(t, originServer)

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"log"
+	"net/http"
+	"time"
+)
+
+var (
+	edgeHost      = flag.String("edgeHost", "www.gov.uk", "Hostname of edge")
+	originPort    = flag.Int("originPort", 8080, "Origin port to listen on for requests")
+	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
+)
+
+// These consts and vars are available to all tests.
+const requestTimeout = time.Second * 5
+
+var (
+	client       *http.Transport
+	originServer *CDNServeMux
+)
+
+// Setup clients and servers.
+func init() {
+
+	flag.Parse()
+
+	tlsOptions := &tls.Config{}
+	if *skipVerifyTLS {
+		tlsOptions.InsecureSkipVerify = true
+	}
+
+	client = &http.Transport{
+		ResponseHeaderTimeout: requestTimeout,
+		TLSClientConfig:       tlsOptions,
+	}
+	originServer = StartServer(*originPort)
+
+	log.Println("Confirming that CDN is healthy")
+	err := confirmEdgeIsHealthy(originServer, *edgeHost)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net/http"
-	"testing"
 	"time"
 )
 
@@ -54,55 +53,6 @@ func NewUUID() string {
 	bs[8] = (bs[8] & 0x3f) | 0x80
 
 	return fmt.Sprintf("%x-%x-%x-%x-%x", bs[0:4], bs[4:6], bs[6:8], bs[8:10], bs[10:])
-}
-
-// CDNServeMux helper should be ready to serve requests when test suite starts
-// and then serve custom handlers each with their own status code.
-func testHelpersCDNServeMuxHandlers(t *testing.T, mux *CDNServeMux) {
-	url := fmt.Sprintf("http://localhost:%d/foo", mux.Port)
-	req, _ := http.NewRequest("GET", url, nil)
-
-	resp, err := client.RoundTrip(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != 200 {
-		t.Error("First request to default handler failed")
-	}
-
-	for _, statusCode := range []int{301, 302, 403, 404} {
-		mux.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(statusCode)
-		})
-
-		resp, err := client.RoundTrip(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp.StatusCode != statusCode {
-			t.Errorf("SwitchHandler didn't work. Got %d, expected %d", resp.StatusCode, statusCode)
-		}
-	}
-}
-
-// CDNServeMux should always respond to HEAD requests in order for the CDN to
-// determine the health of our origin.
-func testHelpersCDNServeMuxProbes(t *testing.T, mux *CDNServeMux) {
-	mux.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("HEAD request incorrectly served by CDNServeMux.handler")
-	})
-
-	url := fmt.Sprintf("http://localhost:%d/", mux.Port)
-	req, _ := http.NewRequest("HEAD", url, nil)
-
-	resp, err := client.RoundTrip(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != 200 || resp.Header.Get("PING") != "PONG" {
-		t.Error("HEAD request for '/' served incorrectly")
-	}
 }
 
 // Confirm that the edge (CDN) is working correctly. This may take some time

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// CDNServeMux helper should be ready to serve requests when test suite starts
+// and then serve custom handlers each with their own status code.
+func TestHelpersCDNServeMuxHandlers(t *testing.T) {
+	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
+	req, _ := http.NewRequest("GET", url, nil)
+
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Error("First request to default handler failed")
+	}
+
+	for _, statusCode := range []int{301, 302, 403, 404} {
+		originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(statusCode)
+		})
+
+		resp, err := client.RoundTrip(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != statusCode {
+			t.Errorf("SwitchHandler didn't work. Got %d, expected %d", resp.StatusCode, statusCode)
+		}
+	}
+}
+
+// CDNServeMux should always respond to HEAD requests in order for the CDN to
+// determine the health of our origin.
+func TestHelpersCDNServeMuxProbes(t *testing.T) {
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("HEAD request incorrectly served by CDNServeMux.handler")
+	})
+
+	url := fmt.Sprintf("http://localhost:%d/", originServer.Port)
+	req, _ := http.NewRequest("HEAD", url, nil)
+
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 200 || resp.Header.Get("PING") != "PONG" {
+		t.Error("HEAD request for '/' served incorrectly")
+	}
+}


### PR DESCRIPTION
Move any setup that is common to all tests - which includes setting global
variables, parsing CLI flags, and doing the pre-flight health check - to a
separate file called `common_setup_test.go` so that it's logically
separated.

The naming of this file seems to have no effect on the setup being performed
before running any of the tests. Presumably because it compiles all test
files that belong to the "main" package.

and.. Move helper tests to helpers_test.go

So that they are logically separated from the actual helper code and match
the normal pattern of `foo_test.go` which tests `foo.go`.

I'm also removing the wrapper which called these individually - now that
they are in a `_test.go` file they will get picked up correctly themselves.
They can still be opted in with `-run Helper`. Plus we'll get the correct
errors if just one of them fail.
