### PR TITLE
Helper Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Run all tests by default. Set this to a regexp matching
+# test names to run if limiting the scope is required.
+RUN := '.+'
+
+mock: vagrant-up vagrant-provision go-mock
+
+test: go-test
+
+clean: vagrant-destroy
+
+go-mock:
+	go test -edgeHost 172.16.20.10 -skipVerifyTLS -test.v -run $(RUN)
+
+go-test:
+	go test -edgeHost $(HOST) -skipVerifyTLS -test.v -run $(RUN)
+
+vagrant-up:
+	vagrant up
+
+vagrant-provision:
+	vagrant provision
+
+vagrant-destroy:
+	vagrant destroy
+


### PR DESCRIPTION
Mostly added to reduce the need to look at the README for how
to run the vagrant mock.

For example:

```
make RUN='XServedBy' mock
```
