### PR TITLE
Reset handler in TestHelpersCDNServeMuxHandlers

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -9,6 +9,8 @@ import (
 // CDNServeMux helper should be ready to serve requests when test suite starts
 // and then serve custom handlers each with their own status code.
 func TestHelpersCDNServeMuxHandlers(t *testing.T) {
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
+
 	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
 	req, _ := http.NewRequest("GET", url, nil)
 


### PR DESCRIPTION
Reset the initial handler in TestHelpersCDNServeMuxHandlers() so that we don't
get the handler of another test. We were originally guarded against it
happening because the test occurred at the very top of the single file, but
after refactoring to separate files it now appears somewhere in the middle.

This caused it to panic when run after the TestNoCacheHeaderSetCookie() test
because an old handler was trying to access a variable that was either no
longer in scope or was using a key that was out of range. Producing this
error:

```
➜  cdn-acceptance-tests git:(master) go test -test.v -edgeHost 172.16.20.10 -skipVerifyTLS -run 'Helper|SetCook'
2014/06/11 16:31:01 Confirming that CDN is healthy
=== RUN TestNoCacheHeaderSetCookie
--- PASS: TestNoCacheHeaderSetCookie (0.00 seconds)
=== RUN TestHelpersCDNServeMuxHandlers
2014/06/11 16:31:01 http: panic serving 127.0.0.1:57297: runtime error: index out of range
goroutine 16 [running]:
net/http.func·009()
        /opt/boxen/homebrew/Cellar/go/1.2.1/libexec/src/pkg/net/http/server.go:1093 +0xae
runtime.panic(0x246dc0, 0x52be17)
        /opt/boxen/homebrew/Cellar/go/1.2.1/libexec/src/pkg/runtime/panic.c:248 +0x106
_/Users/dcarley/projects/govuk/cdn-acceptance-tests.func·009(0x62bcf0, 0xc2100108c0, 0xc210059d00)
        /Users/dcarley/projects/govuk/cdn-acceptance-tests/cdn_acceptance_test.go:234 +0xf7
_/Users/dcarley/projects/govuk/cdn-acceptance-tests.(*CDNServeMux).ServeHTTP(0xc2100386e0, 0x62bcf0, 0xc2100108c0, 0xc210059d00)
        /Users/dcarley/projects/govuk/cdn-acceptance-tests/helpers.go:23 +0x12b
net/http.serverHandler.ServeHTTP(0xc210020460, 0x62bcf0, 0xc2100108c0, 0xc210059d00)
        /opt/boxen/homebrew/Cellar/go/1.2.1/libexec/src/pkg/net/http/server.go:1597 +0x16e
net/http.(*conn).serve(0xc210058f00)
        /opt/boxen/homebrew/Cellar/go/1.2.1/libexec/src/pkg/net/http/server.go:1167 +0x7b7
created by net/http.(*Server).Serve
        /opt/boxen/homebrew/Cellar/go/1.2.1/libexec/src/pkg/net/http/server.go:1644 +0x28b
--- FAIL: TestHelpersCDNServeMuxHandlers (0.00 seconds)
        helpers_test.go:17: EOF
=== RUN TestHelpersCDNServeMuxProbes
--- PASS: TestHelpersCDNServeMuxProbes (0.00 seconds)
FAIL
```
