### PR TITLE
Test for 'Age header set by Edge'. Also includes code to cache IP address.

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -120,7 +120,7 @@ func TestAgeHeaderIsSetByProviderNotOrigin(t *testing.T) {
 
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		if requestReceivedCount == 0 {
-			//w.Header().Set("Age", fmt.Sprintf("%d", originAgeInSeconds))
+			w.Header().Set("Age", fmt.Sprintf("%d", originAgeInSeconds))
 			w.Write([]byte("cacheable request"))
 		} else {
 			t.Error("Unexpected subsequent request received at Origin")

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -125,6 +125,7 @@ func TestAgeHeaderIsSetByProviderNotOrigin(t *testing.T) {
 		} else {
 			t.Error("Unexpected subsequent request received at Origin")
 		}
+		requestReceivedCount++
 	})
 
 	url := fmt.Sprintf("https://%s/?cache-lock=%s", *edgeHost, uuid)

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -161,7 +161,7 @@ func TestErrorPageIsServedWhenNoBackendAvailable(t *testing.T) {
 // Should set an Age header itself rather than passing the Age header from origin.
 func TestAgeHeaderIsSetByProviderNotOrigin(t *testing.T) {
 	const originAgeInSeconds = 100000
-	const secondsToWaitBetweenRequests = 2
+	const secondsToWaitBetweenRequests = 5
 	requestReceivedCount := 0
 	uuid := NewUUID()
 
@@ -183,6 +183,10 @@ func TestAgeHeaderIsSetByProviderNotOrigin(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if resp.StatusCode != 200 {
+		t.Fatalf("Edge returned an unexpected status: %q", resp.Status)
+	}
+
 	// wait a little bit. Edge should update the Age header, we know Origin will not
 	time.Sleep(time.Duration(secondsToWaitBetweenRequests) * time.Second)
 
@@ -191,7 +195,15 @@ func TestAgeHeaderIsSetByProviderNotOrigin(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if resp.StatusCode != 200 {
+		t.Fatal("Edge returned an unexpected status: %q", resp.Status)
+	}
+
 	edgeAgeHeader := resp.Header.Get("Age")
+	if edgeAgeHeader == "" {
+		t.Fatal("Age Header is not set")
+	}
+
 	edgeAgeInSeconds, convErr := strconv.Atoi(edgeAgeHeader)
 	if convErr != nil {
 		t.Fatal(convErr)

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -49,6 +49,9 @@ func init() {
 	}
 }
 
+// CacheHostIpAddress looks up the IP address for a given host name,
+// and caches the first IP address returned. Subsequent requests always
+// return this address, preventing further DNS requests.
 func CachedHostIpAddress(host string) string {
 	if hardCachedEdgeHostIp == "" {
 		ipAddresses, err := net.LookupHost(host)
@@ -60,6 +63,10 @@ func CachedHostIpAddress(host string) string {
 	return hardCachedEdgeHostIp
 }
 
+// HardCachedHostDial acts as a replacement Dial function, ostensibly for
+// http.Transport. It uses the IP address returned by CachedHostIpAddresss
+// and passes that to the stock net.Dial function, to prevent repeat DNS
+// lookups of the provided hostname in addr.
 func HardCachedHostDial(network, addr string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -66,7 +66,8 @@ func CachedHostIpAddress(host string) string {
 // HardCachedHostDial acts as a replacement Dial function, ostensibly for
 // http.Transport. It uses the IP address returned by CachedHostIpAddresss
 // and passes that to the stock net.Dial function, to prevent repeat DNS
-// lookups of the provided hostname in addr.
+// lookups of the provided hostname in addr. This is to prevent us from switching
+// from one CDN location to another mid-test.
 func HardCachedHostDial(network, addr string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -70,5 +69,5 @@ func HardCachedHostDial(network, addr string) (net.Conn, error) {
 		return net.Dial(network, addr)
 	}
 	ipAddr := CachedHostIpAddress(host)
-	return net.Dial(network, fmt.Sprintf("%s:%s", ipAddr, port))
+	return net.Dial(network, net.JoinHostPort(ipAddr, port))
 }


### PR DESCRIPTION
This adds tests to verify the behaviour of the 'Age' header. We discovered that Fastly resets this to '0', regardless of what origin provides.

In the process, it was also highlighted that we need some form of IP address caching - some tests require that we are at least talking to the same edge IP (and hence location), and DNS record timeout was causing an issue for us in this test. A custom `Dial` function has been created in 4a6c5cd to ensure we talk to the same IP address throughout the test suite.
