### PR TITLE
Implement all NoCache tests

### DIFF
--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -32,7 +32,22 @@ func TestNoCacheNewRequestOrigin(t *testing.T) {
 	}
 }
 
-// Should not cache a response with a Set-Cookie header.
+// Should not cache the response to a POST request.
+func TestNoCachePOST(t *testing.T) {
+	t.Error("Not implemented")
+}
+
+// Should not cache the response to a request with a `Authorization` header.
+func TestNoCacheHeaderAuthorization(t *testing.T) {
+	t.Error("Not implemented")
+}
+
+// Should not cache the response to a request with a `Cookie` header.
+func TestNoCacheHeaderCookie(t *testing.T) {
+	t.Error("Not implemented")
+}
+
+// Should not cache a response with a `Set-Cookie` header.
 func TestNoCacheHeaderSetCookie(t *testing.T) {
 	requestsReceivedCount := 0
 	responseBodies := []string{
@@ -69,7 +84,7 @@ func TestNoCacheHeaderSetCookie(t *testing.T) {
 	}
 }
 
-// Should not cache a response with a Cache-Control: private header.
+// Should not cache a response with a `Cache-Control: private` header.
 func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
 	t.Error("Not implemented")
 }

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -50,7 +50,11 @@ func TestNoCacheHeaderAuthorization(t *testing.T) {
 
 // Should not cache the response to a request with a `Cookie` header.
 func TestNoCacheHeaderCookie(t *testing.T) {
-	t.Error("Not implemented")
+	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Cookie", "sekret=mekmitasdigoat")
+
+	testThreeRequestsNotCached(t, req, nil)
 }
 
 // Should not cache a response with a `Set-Cookie` header.

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -71,5 +71,12 @@ func TestNoCacheHeaderSetCookie(t *testing.T) {
 
 // Should not cache a response with a `Cache-Control: private` header.
 func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
-	t.Error("Not implemented")
+	handler := func(h http.Header) {
+		h.Set("Cache-Control", "private")
+	}
+
+	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
+	req, _ := http.NewRequest("GET", url, nil)
+
+	testThreeRequestsNotCached(t, req, handler)
 }

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -34,38 +33,10 @@ func TestNoCacheNewRequestOrigin(t *testing.T) {
 
 // Should not cache the response to a POST request.
 func TestNoCachePOST(t *testing.T) {
-	requestsReceivedCount := 0
-	responseBodies := []string{
-		"first response",
-		"second response",
-		"third response",
-	}
-
-	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(responseBodies[requestsReceivedCount]))
-		requestsReceivedCount++
-	})
-
 	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
 	req, _ := http.NewRequest("POST", url, nil)
 
-	for _, expectedBody := range responseBodies {
-		resp, err := client.RoundTrip(req)
-
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if receivedBody := string(body); receivedBody != expectedBody {
-			t.Errorf("Incorrect response body. Expected %q, got %q", expectedBody, receivedBody)
-		}
-	}
+	testThreeRequestsNotCached(t, req, nil)
 }
 
 // Should not cache the response to a request with a `Authorization` header.
@@ -80,39 +51,14 @@ func TestNoCacheHeaderCookie(t *testing.T) {
 
 // Should not cache a response with a `Set-Cookie` header.
 func TestNoCacheHeaderSetCookie(t *testing.T) {
-	requestsReceivedCount := 0
-	responseBodies := []string{
-		"first response",
-		"second response",
-		"third response",
+	handler := func(h http.Header) {
+		h.Set("Set-Cookie", "sekret=mekmitasdigoat")
 	}
-
-	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Set-Cookie", "sekret=mekmitasdigoat")
-		w.Write([]byte(responseBodies[requestsReceivedCount]))
-		requestsReceivedCount++
-	})
 
 	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
 	req, _ := http.NewRequest("GET", url, nil)
 
-	for _, expectedBody := range responseBodies {
-		resp, err := client.RoundTrip(req)
-
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if receivedBody := string(body); receivedBody != expectedBody {
-			t.Errorf("Incorrect response body. Expected %q, got %q", expectedBody, receivedBody)
-		}
-	}
+	testThreeRequestsNotCached(t, req, handler)
 }
 
 // Should not cache a response with a `Cache-Control: private` header.

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -41,7 +41,11 @@ func TestNoCachePOST(t *testing.T) {
 
 // Should not cache the response to a request with a `Authorization` header.
 func TestNoCacheHeaderAuthorization(t *testing.T) {
-	t.Error("Not implemented")
+	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Basic YXJlbnR5b3U6aW5xdWlzaXRpdmU=")
+
+	testThreeRequestsNotCached(t, req, nil)
 }
 
 // Should not cache the response to a request with a `Cookie` header.

--- a/helpers.go
+++ b/helpers.go
@@ -3,7 +3,9 @@ package main
 import (
 	"crypto/rand"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"testing"
 	"time"
 )
 
@@ -86,5 +88,45 @@ func confirmEdgeIsHealthy(mux *CDNServeMux, edgeHost string) error {
 		time.Sleep(timeBetweenAttempts)
 	}
 	return fmt.Errorf("CDN still not available after %d attempts", maxRetries)
+}
 
+// Callback function to modify response headers.
+type responseHeaderCallback func(h http.Header)
+
+// Helper function to make three requests and verify that we get three
+// unique and uncached responses back. A responseHeaderCallback, if not nil,
+// will be called to modify the response headers.
+func testThreeRequestsNotCached(t *testing.T, req *http.Request, headerCB responseHeaderCallback) {
+	requestsReceivedCount := 0
+	responseBodies := []string{
+		"first response",
+		"second response",
+		"third response",
+	}
+
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		if headerCB != nil {
+			headerCB(w.Header())
+		}
+		w.Write([]byte(responseBodies[requestsReceivedCount]))
+		requestsReceivedCount++
+	})
+
+	for _, expectedBody := range responseBodies {
+		resp, err := client.RoundTrip(req)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if receivedBody := string(body); receivedBody != expectedBody {
+			t.Errorf("Incorrect response body. Expected %q, got %q", expectedBody, receivedBody)
+		}
+	}
 }

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -26,6 +26,12 @@ sub vcl_recv {
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 }
 
+sub vcl_fetch {
+  if (beresp.http.Cache-Control ~ "private") {
+    return (hit_for_pass);
+  }
+}
+
 sub vcl_deliver {
 
   # Mock the X-Served-By header behaviour to match Fastly.


### PR DESCRIPTION
Implement all NoCache tests for standard CDN behaviour. Includes a helper and a mock (see commit for details).

These have uncovered a "bug" probably caused by us returning too early in `vcl_recv`. I'll raise something in Pivotal to fix that in our service configs.

```
--- FAIL: TestNoCacheHeaderAuthorization (0.08 seconds)
        helpers.go:130: Incorrect response body. Expected "second response", got "first response"
        helpers.go:130: Incorrect response body. Expected "third response", got "first response"
=== RUN TestNoCacheHeaderCookie
--- FAIL: TestNoCacheHeaderCookie (0.07 seconds)
        helpers.go:130: Incorrect response body. Expected "second response", got "first response"
        helpers.go:130: Incorrect response body. Expected "third response", got "first response"
```
