### PR TITLE
Fix fmt verb typo in helper error message

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -85,6 +85,6 @@ func confirmEdgeIsHealthy(mux *CDNServeMux, edgeHost string) error {
 		}
 		time.Sleep(timeBetweenAttempts)
 	}
-	return fmt.Errorf("CDN still not available after %n attempts", maxRetries)
+	return fmt.Errorf("CDN still not available after %d attempts", maxRetries)
 
 }


### PR DESCRIPTION
Found by `go vet`:

```
➜  cdn-acceptance-tests git:(master) ✗ go vet
helpers.go:88: unrecognized printf verb 'n'
exit status 1
```

Should be a base10 integer. Otherwise the following message is generated:

```
2014/06/12 11:55:50 CDN still not available after %!n(int=20) attempts
```
