### PR TITLE
Log varnish syntax errors on reload

### DIFF
--- a/mock_cdn_config/modules/varnish/manifests/init.pp
+++ b/mock_cdn_config/modules/varnish/manifests/init.pp
@@ -5,8 +5,16 @@ class varnish {
   file { '/etc/varnish/default.vcl':
     ensure  => file,
     content => template('varnish/default.vcl.erb'),
-  } ~>
+    notify  => Exec['varnish-reload'],
+  } ->
   service { 'varnish':
     ensure => running,
+  }
+
+  # `service varnish reload` doesn't return the right exit code!
+  exec { 'varnish-reload':
+    command     => '/usr/share/varnish/reload-vcl',
+    logoutput   => true,
+    refreshonly => true,
   }
 }


### PR DESCRIPTION
So that you can see what went wrong with the new configuration without
needing to log into the Vagrant VM.
