### PR TITLE
Implement test(s) for X-Forwarded-For

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -52,14 +52,61 @@ func TestRestrictPurgeRequests(t *testing.T) {
 	}
 }
 
-// Should create an X-Forwarded-For header containing the client's IP.
-func TestHeaderCreateXFF(t *testing.T) {
-	t.Error("Not implemented")
-}
+// Should set an `X-Forwarded-For` header for requests that don't already
+// have one and append to requests that already have the header. This test
+// will not work if run from behind a proxy that also sets XFF.
+func TestHeaderXFFCreateAndAppend(t *testing.T) {
+	const headerName = "X-Forwarded-For"
+	const sentHeaderVal = "203.0.113.99"
+	var ourReportedIP net.IP
+	var receivedHeaderVal string
 
-// Should append client's IP to existing X-Forwarded-For header.
-func TestHeaderAppendXFF(t *testing.T) {
-	t.Error("Not implemented")
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaderVal = r.Header.Get(headerName)
+	})
+
+	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
+	req, _ := http.NewRequest("GET", url, nil)
+
+	// First request with no existing XFF.
+	_, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedHeaderVal == "" {
+		t.Fatalf("Origin didn't receive request with %q header", headerName)
+	}
+
+	ourReportedIP = net.ParseIP(receivedHeaderVal)
+	if ourReportedIP == nil {
+		t.Fatalf(
+			"Expected origin to receive %q header with single IP. Got %q",
+			headerName,
+			receivedHeaderVal,
+		)
+	}
+
+	// Use the IP returned by the first response to predict the second.
+	expectedHeaderVal := fmt.Sprintf("%s, %s", sentHeaderVal, ourReportedIP.String())
+
+	// Second request with existing XFF.
+	url = fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
+	req, _ = http.NewRequest("GET", url, nil)
+	req.Header.Set(headerName, sentHeaderVal)
+
+	_, err = client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if receivedHeaderVal != expectedHeaderVal {
+		t.Errorf(
+			"Origin received %q header with wrong value. Expected %q, got %q",
+			headerName,
+			expectedHeaderVal,
+			receivedHeaderVal,
+		)
+	}
 }
 
 // Should create a True-Client-IP header containing the client's IP


### PR DESCRIPTION
I've decided to collapse the two tests together because it's much easier to
construct the expected value of the "append" test when we know what our
reported IP address is from the "create" test. Compared to testing the
number of items and whether they are each a valid IP address.

This test currently fails against our Fastly configuration because we appear
to be appending the same IP twice. I'll raise a bug in Pivotal for that:

```
cdn@gds-cdn-noodle:~/dan$ go test -edgeHost fastly.cdn-acceptance-test.alphagov.co.uk -skipVerifyTLS -v -run XFF
2014/06/13 05:43:40 Confirming that CDN is healthy
=== RUN TestHeaderXFFCreateAndAppend
--- FAIL: TestHeaderXFFCreateAndAppend (0.00 seconds)
        cdn_acceptance_test.go:86: Expected origin to receive "X-Forwarded-For" header with single IP. Got "80.240.128.97, 80.240.128.97"
```
