### PR TITLE
Implement TestHeaderHostUnmodified

### DIFF
--- a/mock_cdn_config/modules/nginx/templates/default.erb
+++ b/mock_cdn_config/modules/nginx/templates/default.erb
@@ -4,6 +4,7 @@ server {
     proxy_pass http://localhost:6081;
     proxy_redirect default;
     proxy_redirect https://localhost:6081 https://<%= @ipaddress_eth1 -%>;
+    proxy_set_header Host $http_host;
   }
 }
 
@@ -13,6 +14,7 @@ server {
   ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
   location / {
     proxy_pass http://localhost:6081;
+    proxy_set_header Host $http_host;
     proxy_set_header Fastly-SSL "true";
     proxy_set_header Fastly-Client-IP $remote_addr;
   }


### PR DESCRIPTION
Verify that the CDN doesn't modify the Host header of the original request.

NB: Go doesn't present `Host` in `http.Header`. It gets stripped off and set
as a field of `http.Request`, as seen here:

https://code.google.com/p/go/source/browse/src/pkg/net/http/request.go?name=go1.2#60
https://code.google.com/p/go/source/browse/src/pkg/net/http/request.go?name=go1.2#576
