### PR TITLE
X-Cache header behaviour tests

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -195,7 +195,38 @@ func TestAgeHeaderIsSetByProviderNotOrigin(t *testing.T) {
 
 // Should set an X-Cache header containing HIT/MISS from 'origin, itself'
 func TestXCacheHeaderContainsHitMissFromBothProviderAndOrigin(t *testing.T) {
-	t.Error("Not implemented")
+
+	const originXCache = "HIT"
+
+	var (
+		xCache         string
+		expectedXCache string
+	)
+
+	uuid := NewUUID()
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Cache", originXCache)
+	})
+
+	sourceUrl := fmt.Sprintf("https://%s/?cache-lock=%s", *edgeHost, uuid)
+
+	// Get first request, will come from origin, cannot be cached - hence cache MISS
+	req, _ := http.NewRequest("GET", sourceUrl, nil)
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xCache = resp.Header.Get("X-Cache")
+	expectedXCache = fmt.Sprintf("%s, MISS", originXCache)
+	if xCache != expectedXCache {
+		t.Errorf(
+			"X-Cache on initial hit is wrong: expected %q, got %q",
+			expectedXCache,
+			xCache,
+		)
+	}
+
 }
 
 // Should set an X-Served-By header giving information on the (Fastly) node and location served from.

--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -229,6 +229,38 @@ func TestXCacheHeaderContainsHitMissFromBothProviderAndOrigin(t *testing.T) {
 
 }
 
+// Should set an X-Cache header containing only MISS if origin does not set an X-Cache Header'
+func TestXCacheHeaderContainsMissOnlyIfOriginDoesNotSetXCache(t *testing.T) {
+
+	const expectedXCache = "MISS"
+
+	var (
+		xCache string
+	)
+
+	uuid := NewUUID()
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
+
+	sourceUrl := fmt.Sprintf("https://%s/?cache-lock=%s", *edgeHost, uuid)
+
+	// Get first request, will come from origin, cannot be cached - hence cache MISS
+	req, _ := http.NewRequest("GET", sourceUrl, nil)
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xCache = resp.Header.Get("X-Cache")
+	if xCache != expectedXCache {
+		t.Errorf(
+			"X-Cache on initial hit is wrong: expected %q, got %q",
+			expectedXCache,
+			xCache,
+		)
+	}
+
+}
+
 // Should set an X-Served-By header giving information on the (Fastly) node and location served from.
 func TestXServedByHeaderContainsFastlyNodeIdAndLocation(t *testing.T) {
 

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -48,6 +48,20 @@ sub vcl_deliver {
     set resp.http.X-Cache-Hits = resp.http.X-Cache-Hits + ", " + obj.hits;
   }
 
+  if(!resp.http.X-Cache) {
+    if (obj.hits > 0) {
+      set resp.http.X-Cache = "HIT";
+    } else {
+      set resp.http.X-Cache = "MISS";
+    }
+  } else {
+    if (obj.hits > 0) {
+      set resp.http.X-Cache = resp.http.X-Cache + ", HIT";
+    } else {
+      set resp.http.X-Cache = resp.http.X-Cache + ", MISS";
+    }
+  }
+
 }
 
 sub vcl_error {


### PR DESCRIPTION
Test cases for:
- Adding to X-Cache header already set by Origin.
- Adding an X-Cache header if Origin has not provided one.

Raised https://github.com/alphagov/cdn-acceptance-tests/issues/38 to discuss the potential for test cases to ensure MISS changes to HIT on subsequent requests.
