### PR TITLE
Use log.Fatal(err) instead of panic(err)

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"testing"
 	"time"
@@ -38,7 +39,7 @@ func StartServer(port int) *CDNServeMux {
 	go func() {
 		err := http.ListenAndServe(addr, mux)
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 	}()
 


### PR DESCRIPTION
When failing to start the server. This prevents the stacktrace of goroutines
from being printed, which isn't very helpful in this use case and makes the
actual error message harder to spot.
