### PR TITLE
Mocks and additional tests for failover

### DIFF
--- a/cdn_acceptance_test.go
+++ b/cdn_acceptance_test.go
@@ -178,14 +178,6 @@ func TestHeaderHostUnmodified(t *testing.T) {
 	}
 }
 
-// Should serve a known static error page if cannot serve a page
-// from origin, stale or any mirror.
-// NB: ideally this should be a page that we control that has a mechanism
-//     to alert us that it has been served.
-func TestErrorPageIsServedWhenNoBackendAvailable(t *testing.T) {
-	t.Error("Not implemented")
-}
-
 // ---------------------------------------------------------
 // Test that useful common cache-related parameters are sent to the
 // client by this CDN provider.

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -4,6 +4,22 @@ import (
 	"testing"
 )
 
+// Should serve a known static error page if all backend servers are down
+// and object isn't in cache/stale.
+// NB: ideally this should be a page that we control that has a mechanism
+//     to alert us that it has been served.
+func TestFailoverErrorPageAllServersDown(t *testing.T) {
+	t.Error("Not implemented")
+}
+
+// Should serve a known static error page if all backend servers return a
+// 5xx response and object isn't in cache/stale.
+// NB: ideally this should be a page that we control that has a mechanism
+//     to alert us that it has been served.
+func TestFailoverErrorPageAllServers5xx(t *testing.T) {
+	t.Error("Not implemented")
+}
+
 // Should serve stale object and not hit mirror(s) if origin is down and
 // object is beyond TTL but still in cache.
 func TestFailoverOriginDownServeStale(t *testing.T) {

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -20,6 +20,12 @@ func TestFailoverErrorPageAllServers5xx(t *testing.T) {
 	t.Error("Not implemented")
 }
 
+// Should back off requests against origin for a very short period of time
+// if origin returns a 5xx response so as not to overwhelm it.
+func TestFailoverOrigin5xxBackOff(t *testing.T) {
+	t.Error("Not implemented")
+}
+
 // Should serve stale object and not hit mirror(s) if origin is down and
 // object is beyond TTL but still in cache.
 func TestFailoverOriginDownServeStale(t *testing.T) {

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -3,6 +3,16 @@ backend default {
   .port = "8080";
 }
 
+backend backup1 {
+  .host = "<%= @ipaddress_vmhost -%>";
+  .port = "8081";
+}
+
+backend backup2 {
+  .host = "<%= @ipaddress_vmhost -%>";
+  .port = "8082";
+}
+
 # Please add the minimal amount of code required to implement/mimic the
 # functionality you need to test. This shouldn't match our real config
 # line-by-line, otherwise we'll have trouble maintaining parity.
@@ -23,10 +33,34 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  set req.grace = 24h;
+
+  # Note that if (req.restarts == 1), we don't change the backend as
+  # we're attempting to serve from stale.
+
+  if (req.restarts > 1) {
+    # Don't serve from stale for backups
+    set req.grace = 0s;
+    set req.backend = backup1;
+  }
+
+  if (req.restarts > 2) {
+    set req.backend = backup2;
+  }
+
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 }
 
 sub vcl_fetch {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    set beresp.grace = 24h;
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     return (hit_for_pass);
   }
@@ -65,6 +99,13 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the backups.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
   if (obj.status == 801) {
      set obj.status = 301;
      set obj.response = "Moved Permanently";


### PR DESCRIPTION
- New CDNServeMux servers and port arguments.
- Split the error page test into 5xx/down.
- Varnish mocks for failover.
- Add empty test for `beresp.saintmode`.
