### PR TITLE
Hard restart Varnish on config changes

### DIFF
--- a/mock_cdn_config/modules/varnish/manifests/init.pp
+++ b/mock_cdn_config/modules/varnish/manifests/init.pp
@@ -5,16 +5,15 @@ class varnish {
   file { '/etc/varnish/default.vcl':
     ensure  => file,
     content => template('varnish/default.vcl.erb'),
-    notify  => Exec['varnish-reload'],
+    notify  => Exec['varnish-restart'],
   } ->
   service { 'varnish':
     ensure => running,
   }
 
-  # `service varnish reload` doesn't return the right exit code!
-  exec { 'varnish-reload':
-    command     => '/usr/share/varnish/reload-vcl',
-    logoutput   => true,
+  # `service varnish restart` doesn't return the right exit code!
+  exec { 'varnish-restart':
+    command     => '/usr/sbin/service varnish stop; /usr/sbin/service varnish start',
     refreshonly => true,
   }
 }


### PR DESCRIPTION
Because reload doesn't clear out old backends. We have to use 'stop;start'
because the init script doesn't propagate the correct exit code from
'restart', even though it calls the same thing. The default of `logoutput =>
on_failure` is fine.
