### PR TITLE
Consistent backend health check

### DIFF
--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -53,12 +53,8 @@ func init() {
 		Dial:                  HardCachedHostDial,
 	}
 
-	originServer = StartServer(*originPort)
-	backupServer1 = StartServer(*backupPort1)
-	backupServer2 = StartServer(*backupPort2)
-
 	log.Println("Confirming that CDN is healthy")
-	err := confirmEdgeIsHealthy(originServer, *edgeHost)
+	err := StartBackendsInOrder(*edgeHost)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -1,16 +1,43 @@
 backend default {
   .host = "<%= @ipaddress_vmhost -%>";
   .port = "8080";
+  .probe = {
+    .request = "HEAD / HTTP/1.1" "Connection: close";
+    .threshold = 1;
+    .window = 2;
+    .timeout = 5s;
+    .initial = 1;
+    .expected_response = 200;
+    .interval = 10s;
+  }
 }
 
 backend backup1 {
   .host = "<%= @ipaddress_vmhost -%>";
   .port = "8081";
+  .probe = {
+    .request = "HEAD / HTTP/1.1" "Connection: close";
+    .threshold = 1;
+    .window = 2;
+    .timeout = 5s;
+    .initial = 1;
+    .expected_response = 200;
+    .interval = 10s;
+  }
 }
 
 backend backup2 {
   .host = "<%= @ipaddress_vmhost -%>";
   .port = "8082";
+  .probe = {
+    .request = "HEAD / HTTP/1.1" "Connection: close";
+    .threshold = 1;
+    .window = 2;
+    .timeout = 5s;
+    .initial = 1;
+    .expected_response = 200;
+    .interval = 10s;
+  }
 }
 
 # Please add the minimal amount of code required to implement/mimic the


### PR DESCRIPTION
Ensure that all our backends are up and running, by ensuing the lower levels are ok before starting the higher levels.

Add probe support to the mock varnish to test this.
