### PR TITLE
Implement two 5xx failover to mirror tests

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -62,17 +62,17 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
 	req, _ := http.NewRequest("GET", url, nil)
 
-	for requestCount := 0; requestCount < 3; requestCount++ {
+	for requestCount := 1; requestCount < 4; requestCount++ {
 		var expectedBody string
 
 		switch requestCount {
-		case 0:
+		case 1:
 			expectedBody = expectedResponseStale
 			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Cache-Control", headerValue)
 				w.Write([]byte(expectedBody))
 			})
-		case 1:
+		case 2:
 			time.Sleep(respTTLWithBuffer)
 
 			expectedBody = expectedResponseStale
@@ -80,7 +80,7 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				w.Write([]byte(originServer.Name))
 			})
-		case 2:
+		case 3:
 			time.Sleep(waitSaintMode)
 
 			expectedBody = expectedResponseFresh
@@ -101,7 +101,8 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 		}
 		if bodyStr := string(body); bodyStr != expectedBody {
 			t.Errorf(
-				"Received incorrect response body. Expected %q, got %q",
+				"Request %d received incorrect response body. Expected %q, got %q",
+				requestCount,
 				expectedBody,
 				bodyStr,
 			)

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -65,14 +65,14 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 	var expectedBody string
 	for requestCount := 1; requestCount < 6; requestCount++ {
 		switch requestCount {
-		case 1:
+		case 1: // Request 1 populates cache.
 			expectedBody = expectedResponseStale
 
 			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Cache-Control", headerValue)
 				w.Write([]byte(expectedBody))
 			})
-		case 2:
+		case 2: // Requests 2,3,4 come from stale.
 			time.Sleep(respTTLWithBuffer)
 			expectedBody = expectedResponseStale
 
@@ -80,7 +80,7 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				w.Write([]byte(originServer.Name))
 			})
-		case 5:
+		case 5: // Last request comes directly from origin again.
 			time.Sleep(waitSaintMode)
 			expectedBody = expectedResponseFresh
 

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -62,28 +62,28 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
 	req, _ := http.NewRequest("GET", url, nil)
 
-	for requestCount := 1; requestCount < 4; requestCount++ {
-		var expectedBody string
-
+	var expectedBody string
+	for requestCount := 1; requestCount < 6; requestCount++ {
 		switch requestCount {
 		case 1:
 			expectedBody = expectedResponseStale
+
 			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Cache-Control", headerValue)
 				w.Write([]byte(expectedBody))
 			})
 		case 2:
 			time.Sleep(respTTLWithBuffer)
-
 			expectedBody = expectedResponseStale
+
 			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				w.Write([]byte(originServer.Name))
 			})
-		case 3:
+		case 5:
 			time.Sleep(waitSaintMode)
-
 			expectedBody = expectedResponseFresh
+
 			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(expectedBody))
 			})


### PR DESCRIPTION
These both currently fail against the real service because `beresp.saintmode` doesn't appear to be working as expected:

```
=== RUN TestFailoverOrigin5xxUseFirstMirror
--- FAIL: TestFailoverOrigin5xxUseFirstMirror (0.08 seconds)
        cdn_failover_test.go:63: Server origin received more than one request
        cdn_failover_test.go:108: Received incorrect response body. Expected "lucky golden ticket", got "origin"
=== RUN TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror
--- FAIL: TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror (0.05 seconds)
        cdn_failover_test.go:131: Server origin received more than one request
        cdn_failover_test.go:181: Received incorrect response body. Expected "lucky golden ticket", got "origin"
```

/cc @mattbostock 
