### PR TITLE
Stoppable HTTP Servers

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"log"
+	"net/http"
 	"testing"
+	"time"
 )
 
 // Should serve a known static error page if all backend servers are down
@@ -9,7 +13,32 @@ import (
 // NB: ideally this should be a page that we control that has a mechanism
 //     to alert us that it has been served.
 func TestFailoverErrorPageAllServersDown(t *testing.T) {
-	t.Error("Not implemented")
+	originServer.Stop()
+	backupServer1.Stop()
+	backupServer2.Stop()
+	time.Sleep(5 * time.Second)
+
+	sourceUrl := fmt.Sprintf("https://%s/?cache-bust=%s", *edgeHost, NewUUID())
+	req, err := http.NewRequest("GET", sourceUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 503 {
+		t.Errorf("Invalid StatusCode received. Expected 503, got %d", resp.StatusCode)
+	}
+
+	err = StartBackendsInOrder(*edgeHost)
+	if err != nil {
+		// Bomb out - we do not have a consistent backend, so subsequent tests
+		// would fail in unexpected ways.
+		log.Fatal(err)
+	}
+
 }
 
 // Should serve a known static error page if all backend servers return a

--- a/helpers.go
+++ b/helpers.go
@@ -50,7 +50,7 @@ func StartServer(name string, port int) *CDNServeMux {
 	return mux
 }
 
-func StopServer(mux *CDNServeMux) {
+func (mux *CDNServeMux) Stop() {
 	err := mux.Listener.Close()
 	if err != nil {
 		log.Fatal(err)

--- a/helpers.go
+++ b/helpers.go
@@ -55,6 +55,9 @@ func StopServer(mux *CDNServeMux) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	mux.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "close")
+	})
 }
 
 func StoppableHttpListenAndServe(addr string, mux *CDNServeMux) error {

--- a/helpers.go
+++ b/helpers.go
@@ -58,6 +58,18 @@ func (mux *CDNServeMux) Stop() {
 	mux.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Connection", "close")
 	})
+
+	uuid := NewUUID()
+	sourceUrl := fmt.Sprintf("https://%s/?cacheBuster=%s", *edgeHost, uuid)
+	req, err := http.NewRequest("GET", sourceUrl, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = client.RoundTrip(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 }
 
 func StoppableHttpListenAndServe(addr string, mux *CDNServeMux) error {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 )
 
@@ -55,4 +56,32 @@ func TestHelpersCDNServeMuxProbes(t *testing.T) {
 	if resp.StatusCode != 200 || resp.Header.Get("PING") != "PONG" {
 		t.Error("HEAD request for '/' served incorrectly")
 	}
+}
+
+func TestHelpersCDNServeStop(t *testing.T) {
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
+
+	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
+	req, _ := http.NewRequest("GET", url, nil)
+
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Error("originServer should be up and responding, prior to Stop operation")
+	}
+
+	originServer.Stop()
+
+	resp, err = client.RoundTrip(req)
+	if err == nil {
+		t.Error("Client connection succeeded. The server should be refusing requests by now.")
+	}
+
+	re := regexp.MustCompile(`connection refused`)
+	if !re.MatchString(fmt.Sprintf("%s", err)) {
+		t.Error("Connection error %q is not as expected", err)
+	}
+
 }

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -125,21 +125,6 @@ sub vcl_deliver {
 
 }
 
-sub vcl_pass {
-  // disable keep-alives
-  set bereq.http.connection = "close";
-}
-
-sub vcl_miss {
-  // disable keep-alives
-  set bereq.http.connection = "close";
-}
-
-sub vcl_pipe {
-  // disable keep-alives
-  set bereq.http.connection = "close";
-}
-
 sub vcl_error {
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -125,6 +125,21 @@ sub vcl_deliver {
 
 }
 
+sub vcl_pass {
+  // disable keep-alives
+  set bereq.http.connection = "close";
+}
+
+sub vcl_miss {
+  // disable keep-alives
+  set bereq.http.connection = "close";
+}
+
+sub vcl_pipe {
+  // disable keep-alives
+  set bereq.http.connection = "close";
+}
+
 sub vcl_error {
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try


### PR DESCRIPTION
This adds support for stopping a given HTTP Listener, ready for use in the Failover tests. 

Two steps are required due to Varnish/Edge keeping persistent connections open:
- Close the listener, preventing any new connections.
- Switch the handler to return 'Connection: close' on subsequent requests. Varnish respects this and closes the connection.
