### PR TITLE
[Fixes #37] Request helpers

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -89,10 +89,7 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 			})
 		}
 
-		resp, err := client.RoundTrip(req)
-		if err != nil {
-			t.Fatal(err)
-		}
+		resp := RoundTripCheckError(t, req)
 
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
@@ -151,11 +148,8 @@ func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
 
 	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
 	req, _ := http.NewRequest("GET", url, nil)
-	resp, err := client.RoundTrip(req)
+	resp := RoundTripCheckError(t, req)
 
-	if err != nil {
-		t.Fatal(err)
-	}
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
 			"Received incorrect status code. Expected %d, got %d",
@@ -224,11 +218,8 @@ func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
 
 	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
 	req, _ := http.NewRequest("GET", url, nil)
-	resp, err := client.RoundTrip(req)
+	resp := RoundTripCheckError(t, req)
 
-	if err != nil {
-		t.Fatal(err)
-	}
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
 			"Received incorrect status code. Expected %d, got %d",

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -59,8 +59,7 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 		w.Write([]byte(name))
 	})
 
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
+	req := NewUniqueEdgeGET(t)
 
 	var expectedBody string
 	for requestCount := 1; requestCount < 6; requestCount++ {
@@ -146,8 +145,7 @@ func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
 		w.Write([]byte(name))
 	})
 
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
+	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
 
 	if resp.StatusCode != expectedStatus {
@@ -216,8 +214,7 @@ func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
 		}
 	})
 
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
+	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
 
 	if resp.StatusCode != expectedStatus {

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -30,16 +30,15 @@ func TestNoCacheNewRequestOrigin(t *testing.T) {
 
 // Should not cache the response to a POST request.
 func TestNoCachePOST(t *testing.T) {
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("POST", url, nil)
+	req := NewUniqueEdgeGET(t)
+	req.Method = "POST"
 
 	testThreeRequestsNotCached(t, req, nil)
 }
 
 // Should not cache the response to a request with a `Authorization` header.
 func TestNoCacheHeaderAuthorization(t *testing.T) {
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
+	req := NewUniqueEdgeGET(t)
 	req.Header.Set("Authorization", "Basic YXJlbnR5b3U6aW5xdWlzaXRpdmU=")
 
 	testThreeRequestsNotCached(t, req, nil)
@@ -47,8 +46,7 @@ func TestNoCacheHeaderAuthorization(t *testing.T) {
 
 // Should not cache the response to a request with a `Cookie` header.
 func TestNoCacheHeaderCookie(t *testing.T) {
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
+	req := NewUniqueEdgeGET(t)
 	req.Header.Set("Cookie", "sekret=mekmitasdigoat")
 
 	testThreeRequestsNotCached(t, req, nil)
@@ -60,9 +58,7 @@ func TestNoCacheHeaderSetCookie(t *testing.T) {
 		h.Set("Set-Cookie", "sekret=mekmitasdigoat")
 	}
 
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
-
+	req := NewUniqueEdgeGET(t)
 	testThreeRequestsNotCached(t, req, handler)
 }
 
@@ -72,8 +68,6 @@ func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
 		h.Set("Cache-Control", "private")
 	}
 
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
-
+	req := NewUniqueEdgeGET(t)
 	testThreeRequestsNotCached(t, req, handler)
 }

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -18,11 +18,8 @@ func TestNoCacheNewRequestOrigin(t *testing.T) {
 	sourceUrl := fmt.Sprintf("https://%s/%s", *edgeHost, uuid)
 
 	req, _ := http.NewRequest("GET", sourceUrl, nil)
-	resp, err := client.RoundTrip(req)
+	resp := RoundTripCheckError(t, req)
 
-	if err != nil {
-		t.Fatal(err)
-	}
 	if resp.StatusCode != 200 {
 		t.Errorf("Status code expected 200, got %d", resp.StatusCode)
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -13,11 +13,8 @@ func TestHelpersCDNServeMuxHandlers(t *testing.T) {
 
 	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
 	req, _ := http.NewRequest("GET", url, nil)
+	resp := RoundTripCheckError(t, req)
 
-	resp, err := client.RoundTrip(req)
-	if err != nil {
-		t.Fatal(err)
-	}
 	if resp.StatusCode != 200 {
 		t.Error("First request to default handler failed")
 	}
@@ -27,10 +24,7 @@ func TestHelpersCDNServeMuxHandlers(t *testing.T) {
 			w.WriteHeader(statusCode)
 		})
 
-		resp, err := client.RoundTrip(req)
-		if err != nil {
-			t.Fatal(err)
-		}
+		resp := RoundTripCheckError(t, req)
 		if resp.StatusCode != statusCode {
 			t.Errorf("SwitchHandler didn't work. Got %d, expected %d", resp.StatusCode, statusCode)
 		}
@@ -46,11 +40,7 @@ func TestHelpersCDNServeMuxProbes(t *testing.T) {
 
 	url := fmt.Sprintf("http://localhost:%d/", originServer.Port)
 	req, _ := http.NewRequest("HEAD", url, nil)
-
-	resp, err := client.RoundTrip(req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := RoundTripCheckError(t, req)
 
 	if resp.StatusCode != 200 || resp.Header.Get("PING") != "PONG" {
 		t.Error("HEAD request for '/' served incorrectly")


### PR DESCRIPTION
#### RoundTripCheckError helper

Move all calls to `client.RoundTrip` into a helper function. This reduces
our use of the `client` global variable and the repetition of checking
request errors. It also gives us a handy place to document why we're using
`RoundTrip` instead of `Do` or `Get`.
#### NewUniqueEdgeGET helper

Because:
- We do a lot of creating `http.Request` without checking errors. Which is
  dangerous, as Mike found out, because we'll get a nil object if there's a
  problem with the URL and cause `client.RoundTrip` to panic.
- It reduces our use of the global pointer variable `*edgeHost`.
- Standardises the URL pattern to always be a query param. Which will allow
  more tests to work against production, but shouldn't affect their existing
  behaviour.

There are two instances where I'm modifying the request method on the object
returned by NewUniqueEdgeGET. Which, despite the name, I think is OK.
Because it's still quite clear what they're doing and it's better than them
being vastly different.

There are also two instances that aren't using the helper because they
currently use the UUID to construct the response handler.
