### PR TITLE
Stoppable HTTP Servers

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -19,21 +19,14 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 	backupServer1.Stop()
 	backupServer2.Stop()
 
-	sourceUrl := fmt.Sprintf("https://%s/?cache-bust=%s", *edgeHost, NewUUID())
-	req, err := http.NewRequest("GET", sourceUrl, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := client.RoundTrip(req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := NewUniqueEdgeGET(t)
+	resp := RoundTripCheckError(t, req)
 
 	if resp.StatusCode != 503 {
 		t.Errorf("Invalid StatusCode received. Expected 503, got %d", resp.StatusCode)
 	}
 
-	err = StartBackendsInOrder(*edgeHost)
+	err := StartBackendsInOrder(*edgeHost)
 	if err != nil {
 		// Bomb out - we do not have a consistent backend, so subsequent tests
 		// would fail in unexpected ways.

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"testing"
 	"time"
@@ -26,12 +25,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		t.Errorf("Invalid StatusCode received. Expected 503, got %d", resp.StatusCode)
 	}
 
-	err := StartBackendsInOrder(*edgeHost)
-	if err != nil {
-		// Bomb out - we do not have a consistent backend, so subsequent tests
-		// would fail in unexpected ways.
-		log.Fatal(err)
-	}
+	StartBackendsInOrder(*edgeHost)
 
 }
 

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -54,10 +54,8 @@ func init() {
 	}
 
 	log.Println("Confirming that CDN is healthy")
-	err := StartBackendsInOrder(*edgeHost)
-	if err != nil {
-		log.Fatal(err)
-	}
+	StartBackendsInOrder(*edgeHost)
+
 }
 
 // CacheHostIpAddress looks up the IP address for a given host name,

--- a/helpers.go
+++ b/helpers.go
@@ -64,6 +64,10 @@ func StoppableHttpListenAndServe(addr string, mux *CDNServeMux) error {
 	return nil
 }
 
+func (mux *CDNServeMux) Stop() {
+	mux.server.Close()
+}
+
 // Return a v4 (random) UUID string.
 // This might not be strictly RFC4122 compliant, but it will do. Credit:
 // https://groups.google.com/d/msg/golang-nuts/Rn13T6BZpgE/dBaYVJ4hB5gJ

--- a/helpers.go
+++ b/helpers.go
@@ -126,16 +126,16 @@ func RoundTripCheckError(t *testing.T, req *http.Request) *http.Response {
 //
 // We assume that all backends are stopped, so that we can start them in order.
 //
-func StartBackendsInOrder(edgeHost string) (err error) {
+func StartBackendsInOrder(edgeHost string) {
 
 	backupServer2 = StartServer("backup2", *backupPort2)
 	backupServer2.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Backend-Marker", backupServer2.Name)
 		w.WriteHeader(200)
 	})
-	err = waitForBackend(edgeHost, backupServer2.Name)
+	err := waitForBackend(edgeHost, backupServer2.Name)
 	if err != nil {
-		return
+		log.Fatal(err)
 	}
 
 	backupServer1 = StartServer("backup1", *backupPort1)
@@ -145,7 +145,7 @@ func StartBackendsInOrder(edgeHost string) (err error) {
 	})
 	err = waitForBackend(edgeHost, backupServer1.Name)
 	if err != nil {
-		return
+		log.Fatal(err)
 	}
 
 	originServer = StartServer("origin", *originPort)
@@ -155,11 +155,8 @@ func StartBackendsInOrder(edgeHost string) (err error) {
 	})
 	err = waitForBackend(edgeHost, originServer.Name)
 	if err != nil {
-		return
+		log.Fatal(err)
 	}
-
-	// All is well
-	return nil
 
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -35,6 +35,10 @@ func (s *CDNServeMux) SwitchHandler(h func(w http.ResponseWriter, r *http.Reques
 	s.handler = h
 }
 
+func (s *CDNServeMux) Stop() {
+	s.server.Close()
+}
+
 // Start a new server and return the CDNServeMux used.
 func StartServer(name string, port int) *CDNServeMux {
 	handler := func(w http.ResponseWriter, r *http.Request) {}
@@ -62,10 +66,6 @@ func StoppableHttpListenAndServe(addr string, mux *CDNServeMux) error {
 	server.Listener = l
 	server.Start()
 	return nil
-}
-
-func (mux *CDNServeMux) Stop() {
-	mux.server.Close()
 }
 
 // Return a v4 (random) UUID string.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -74,4 +74,9 @@ func TestHelpersCDNServeStop(t *testing.T) {
 		t.Errorf("Connection error %q is not as expected", err)
 	}
 
+	// Reset back to a known-good state
+	backupServer1.Stop()
+	backupServer2.Stop()
+	StartBackendsInOrder(*edgeHost)
+
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 )
 
@@ -45,4 +46,32 @@ func TestHelpersCDNServeMuxProbes(t *testing.T) {
 	if resp.StatusCode != 200 || resp.Header.Get("PING") != "PONG" {
 		t.Error("HEAD request for '/' served incorrectly")
 	}
+}
+
+func TestHelpersCDNServeStop(t *testing.T) {
+	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
+
+	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
+	req, _ := http.NewRequest("GET", url, nil)
+
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Error("originServer should be up and responding, prior to Stop operation")
+	}
+
+	originServer.Stop()
+
+	resp, err = client.RoundTrip(req)
+	if err == nil {
+		t.Error("Client connection succeeded. The server should be refusing requests by now.")
+	}
+
+	re := regexp.MustCompile(`EOF`)
+	if !re.MatchString(fmt.Sprintf("%s", err)) {
+		t.Errorf("Connection error %q is not as expected", err)
+	}
+
 }


### PR DESCRIPTION
This adds support for stopping a given HTTP Listener, ready for use in the Failover tests.

It is a reimplementation of #48, using the net/http/httptest HTTP Server rather than the regular net/http one. httptest keeps a record of client connections, and its Close() method shuts these down - exactly the functionality we need.
