### PR TITLE
Rename CDNServeMux to CDNBackendServer

### DIFF
--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -24,9 +24,9 @@ const requestTimeout = time.Second * 5
 
 var (
 	client        *http.Transport
-	originServer  *CDNServeMux
-	backupServer1 *CDNServeMux
-	backupServer2 *CDNServeMux
+	originServer  *CDNBackendServer
+	backupServer1 *CDNBackendServer
+	backupServer2 *CDNBackendServer
 )
 
 var hardCachedEdgeHostIp string

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 )
 
-// CDNServeMux helper should be ready to serve requests when test suite starts
-// and then serve custom handlers each with their own status code.
-func TestHelpersCDNServeMuxHandlers(t *testing.T) {
+// CDNBackendServer instance should be ready to serve requests when test
+// suite starts and then serve custom handlers each with their own status
+// code.
+func TestHelpersCDNBackendServerHandlers(t *testing.T) {
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
 
 	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
@@ -32,11 +33,11 @@ func TestHelpersCDNServeMuxHandlers(t *testing.T) {
 	}
 }
 
-// CDNServeMux should always respond to HEAD requests in order for the CDN to
-// determine the health of our origin.
-func TestHelpersCDNServeMuxProbes(t *testing.T) {
+// CDNBackendServer should always respond to HEAD requests in order for the
+// CDN to determine the health of our origin.
+func TestHelpersCDNBackendServerProbes(t *testing.T) {
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("HEAD request incorrectly served by CDNServeMux.handler")
+		t.Error("HEAD request incorrectly served by CDNBackendServer.handler")
 	})
 
 	url := fmt.Sprintf("http://localhost:%d/", originServer.Port)


### PR DESCRIPTION
This was never technically a ServeMux because it sends all requests,
regardless of path, to the same handlerfunc. Although it implements
http.Handler I don't think it's a "handler" either because it also contains
references to the underlying server. So CDNBackendServer seems like the most
appropriate name for it.
