### PR TITLE
Add a jenkins.sh to run these tests

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+test -z "$TEST_EDGEHOST" && export TEST_EDGEHOST="172.16.20.10"
+if [ "$TEST_VERIFYTLS" = "yes" ]; then
+    export TEST_ARGS="";
+else
+    export TEST_ARGS="-skipVerifyTLS";
+fi
+echo "Running: go test -edgeHost $TEST_EDGEHOST $TEST_ARGS"
+go test -edgeHost $TEST_EDGEHOST $TEST_ARGS


### PR DESCRIPTION
This adds a jenkins.sh script which will run the tests from Jenkins.

The defaults with no environment is to run `go test -edgeHost 172.16.20.10 -skipVerifyTLS` and
`TEST_EDGEHOST` will override the edgeHost (for verifying against a real CDN) and setting
`TEST_VERIFYTLS` to `"yes"` will enable TLS verification if you have a real certificate for
your CDN service.
