### PR TITLE
Reset backends before each test

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ When writing new tests please be sure to:
   "custom failover"
 - use a consistent naming prefix for the functions that so that they can be
   run as a group e.g. `func TestCustomFailover…(…)`
-- always call `SwitchHandler(…)` at the beginning of a test for any
-  `CDNServeMux` you intend to use during that test. Even if it is just to
-  reset the handler to an empty function. Otherwise you may experience
-  undesired effects such as runtime panics.
+- always call `ResetBackendsInOrder()` at the beginning of each test to
+  ensure that all of the backends are running and have their handlers reset
+  from previous tests.
 - Define static inputs such as "number of requests" or "time between
   requests" at the beginning of the test so that they're easy to locate. Use
   constants where possible to indicate that they won't be changed at

--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -11,12 +11,16 @@ import (
 // doesn't specify it's own cache headers. Subsequent requests should return
 // a cached response.
 func TestCacheFirstResponse(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	testRequestsCachedIndefinite(t, nil)
 }
 
 // Should cache responses for the period defined in a `Expires: n` response
 // header.
 func TestCacheExpires(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	const cacheDuration = time.Duration(5 * time.Second)
 
 	handler := func(w http.ResponseWriter) {
@@ -30,6 +34,8 @@ func TestCacheExpires(t *testing.T) {
 // Should cache responses for the period defined in a `Cache-Control:
 // max-age=n` response header.
 func TestCacheCacheControlMaxAge(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	const cacheDuration = time.Duration(5 * time.Second)
 	headerValue := fmt.Sprintf("max-age=%.0f", cacheDuration.Seconds())
 
@@ -43,6 +49,8 @@ func TestCacheCacheControlMaxAge(t *testing.T) {
 // Should cache responses for the period defined in a `Cache-Control:
 // max-age=n` response header when a `Expires: n*2` header is also present.
 func TestCacheExpiresAndMaxAge(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	const cacheDuration = time.Duration(5 * time.Second)
 	const expiresDuration = cacheDuration * 2
 
@@ -61,6 +69,8 @@ func TestCacheExpiresAndMaxAge(t *testing.T) {
 // Should cache responses with a `Cache-Control: no-cache` header. Varnish
 // doesn't respect this by default.
 func TestCacheCacheControlNoCache(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	handler := func(w http.ResponseWriter) {
 		w.Header().Set("Cache-Control", "no-cache")
 	}
@@ -72,6 +82,8 @@ func TestCacheCacheControlNoCache(t *testing.T) {
 // misconception that 404 responses shouldn't be cached; they should because
 // they can be expensive to generate.
 func TestCache404Response(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	handler := func(w http.ResponseWriter) {
 		w.WriteHeader(http.StatusNotFound)
 	}

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -14,6 +14,8 @@ import (
 // NB: ideally this should be a page that we control that has a mechanism
 //     to alert us that it has been served.
 func TestFailoverErrorPageAllServersDown(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	const expectedStatusCode = http.StatusServiceUnavailable
 	const expectedBody = "Guru Meditation"
 
@@ -45,8 +47,6 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 			bodyStr,
 		)
 	}
-
-	ResetBackends(backendsByPriority)
 }
 
 // Should serve a known static error page if all backend servers return a
@@ -72,6 +72,8 @@ func TestFailoverOriginDownServeStale(t *testing.T) {
 // Should serve stale object and not hit mirror(s) if origin returns a 5xx
 // response and object is beyond TTL but still in cache.
 func TestFailoverOrigin5xxServeStale(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	const expectedResponseStale = "going off like stilton"
 	const expectedResponseFresh = "as fresh as daisies"
 
@@ -148,6 +150,8 @@ func TestFailoverOriginDownUseFirstMirror(t *testing.T) {
 // Should fallback to first mirror if origin returns 5xx response and object
 // is not in cache (active or stale).
 func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	expectedBody := "lucky golden ticket"
 	expectedStatus := http.StatusOK
 	backendsSawRequest := map[string]bool{}
@@ -212,6 +216,8 @@ func TestFailoverOriginDownFirstMirrorDownUseSecondMirror(t *testing.T) {
 // Should fallback to second mirror if both origin and first mirror return
 // 5xx responses.
 func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	expectedBody := "lucky golden ticket"
 	expectedStatus := http.StatusOK
 	backendsSawRequest := map[string]bool{}
@@ -276,6 +282,8 @@ func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
 // No-Fallback header. In order to allow applications to present their own
 // error pages.
 func TestFailoverNoFallbackHeader(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	const headerName = "No-Fallback"
 	const expectedStatus = http.StatusServiceUnavailable
 	const expectedBody = "custom error page"

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -46,7 +46,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		)
 	}
 
-	ResetBackends(*edgeHost, backendsByPriority)
+	ResetBackends(backendsByPriority)
 }
 
 // Should serve a known static error page if all backend servers return a

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -46,7 +46,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		)
 	}
 
-	StartBackendsInOrder(*edgeHost)
+	StartBackendsInOrder(*edgeHost, backendsByPriority)
 }
 
 // Should serve a known static error page if all backend servers return a

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -46,7 +46,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		)
 	}
 
-	StartBackendsInOrder(*edgeHost, backendsByPriority)
+	ResetBackends(*edgeHost, backendsByPriority)
 }
 
 // Should serve a known static error page if all backend servers return a

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -8,7 +8,10 @@ import (
 
 // Should send request to origin by default
 func TestNoCacheNewRequestOrigin(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	uuid := NewUUID()
+
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" && r.URL.Path == fmt.Sprintf("/%s", uuid) {
 			w.Header().Set("EnsureOriginServed", uuid)
@@ -30,6 +33,8 @@ func TestNoCacheNewRequestOrigin(t *testing.T) {
 
 // Should not cache the response to a POST request.
 func TestNoCachePOST(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	req := NewUniqueEdgeGET(t)
 	req.Method = "POST"
 
@@ -38,6 +43,8 @@ func TestNoCachePOST(t *testing.T) {
 
 // Should not cache the response to a request with a `Authorization` header.
 func TestNoCacheHeaderAuthorization(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	req := NewUniqueEdgeGET(t)
 	req.Header.Set("Authorization", "Basic YXJlbnR5b3U6aW5xdWlzaXRpdmU=")
 
@@ -46,6 +53,8 @@ func TestNoCacheHeaderAuthorization(t *testing.T) {
 
 // Should not cache the response to a request with a `Cookie` header.
 func TestNoCacheHeaderCookie(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	req := NewUniqueEdgeGET(t)
 	req.Header.Set("Cookie", "sekret=mekmitasdigoat")
 
@@ -54,6 +63,8 @@ func TestNoCacheHeaderCookie(t *testing.T) {
 
 // Should not cache a response with a `Set-Cookie` header.
 func TestNoCacheHeaderSetCookie(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	handler := func(h http.Header) {
 		h.Set("Set-Cookie", "sekret=mekmitasdigoat")
 	}
@@ -64,6 +75,8 @@ func TestNoCacheHeaderSetCookie(t *testing.T) {
 
 // Should not cache a response with a `Cache-Control: private` header.
 func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	handler := func(h http.Header) {
 		h.Set("Cache-Control", "private")
 	}

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -74,7 +74,7 @@ func init() {
 	}
 
 	log.Println("Confirming that CDN is healthy")
-	ResetBackends(*edgeHost, backendsByPriority)
+	ResetBackends(backendsByPriority)
 
 }
 

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -23,10 +23,11 @@ var (
 const requestTimeout = time.Second * 5
 
 var (
-	client        *http.Transport
-	originServer  *CDNBackendServer
-	backupServer1 *CDNBackendServer
-	backupServer2 *CDNBackendServer
+	client             *http.Transport
+	originServer       *CDNBackendServer
+	backupServer1      *CDNBackendServer
+	backupServer2      *CDNBackendServer
+	backendsByPriority []*CDNBackendServer
 )
 
 var hardCachedEdgeHostIp string
@@ -53,8 +54,27 @@ func init() {
 		Dial:                  HardCachedHostDial,
 	}
 
+	originServer = &CDNBackendServer{
+		Name: "origin",
+		Port: *originPort,
+	}
+	backupServer1 = &CDNBackendServer{
+		Name: "backup1",
+		Port: *backupPort1,
+	}
+	backupServer2 = &CDNBackendServer{
+		Name: "backup2",
+		Port: *backupPort2,
+	}
+
+	backendsByPriority = []*CDNBackendServer{
+		originServer,
+		backupServer1,
+		backupServer2,
+	}
+
 	log.Println("Confirming that CDN is healthy")
-	StartBackendsInOrder(*edgeHost)
+	StartBackendsInOrder(*edgeHost, backendsByPriority)
 
 }
 

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -74,7 +74,7 @@ func init() {
 	}
 
 	log.Println("Confirming that CDN is healthy")
-	StartBackendsInOrder(*edgeHost, backendsByPriority)
+	ResetBackends(*edgeHost, backendsByPriority)
 
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -53,30 +53,18 @@ func (s *CDNBackendServer) Stop() {
 
 func (s *CDNBackendServer) Start() {
 	s.ResetHandler()
+
 	addr := fmt.Sprintf(":%d", s.Port)
-
-	go func() {
-		err := StoppableHttpListenAndServe(addr, s)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	log.Printf("Started server on port %d", s.Port)
-}
-
-func StoppableHttpListenAndServe(addr string, backend *CDNBackendServer) error {
-	server := httptest.NewUnstartedServer(backend)
-	backend.server = server
-
-	l, e := net.Listen("tcp", addr)
-	if e != nil {
-		log.Fatal(e)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	server.Listener = l
-	server.Start()
-	return nil
+	s.server = httptest.NewUnstartedServer(s)
+	s.server.Listener = ln
+	s.server.Start()
+
+	log.Printf("Started server on port %d", s.Port)
 }
 
 // Return a v4 (random) UUID string.

--- a/helpers.go
+++ b/helpers.go
@@ -133,29 +133,14 @@ func RoundTripCheckError(t *testing.T, req *http.Request) *http.Response {
 //
 // We assume that all backends are stopped, so that we can start them in order.
 //
-func StartBackendsInOrder(edgeHost string) {
-
-	backupServer2 = &CDNBackendServer{"backup2", *backupPort2, nil, nil}
-	backupServer2.Start()
-	err := waitForBackend(edgeHost, backupServer2.Name)
-	if err != nil {
-		log.Fatal(err)
+func StartBackendsInOrder(edgeHost string, backends []*CDNBackendServer) {
+	for i := len(backends); i > 0; i-- {
+		backends[i-1].Start()
+		err := waitForBackend(edgeHost, backends[i-1].Name)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
-
-	backupServer1 = &CDNBackendServer{"backup1", *backupPort1, nil, nil}
-	backupServer1.Start()
-	err = waitForBackend(edgeHost, backupServer1.Name)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	originServer = &CDNBackendServer{"origin", *originPort, nil, nil}
-	originServer.Start()
-	err = waitForBackend(edgeHost, originServer.Name)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 }
 
 // Wait for the backend to return with the header we expect. This is designed to

--- a/helpers.go
+++ b/helpers.go
@@ -42,8 +42,13 @@ func (s *CDNBackendServer) SwitchHandler(h func(w http.ResponseWriter, r *http.R
 	s.handler = h
 }
 
+func (s *CDNBackendServer) IsStarted() bool {
+	return (s.server != nil)
+}
+
 func (s *CDNBackendServer) Stop() {
 	s.server.Close()
+	s.server = nil
 }
 
 func (s *CDNBackendServer) Start() {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -93,6 +93,6 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	// Reset back to a known-good state
 	backupServer1.Stop()
 	backupServer2.Stop()
-	ResetBackends(*edgeHost, backendsByPriority)
+	ResetBackends(backendsByPriority)
 
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -11,7 +11,7 @@ import (
 // suite starts and then serve custom handlers each with their own status
 // code.
 func TestHelpersCDNBackendServerHandlers(t *testing.T) {
-	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
+	ResetBackends(backendsByPriority)
 
 	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
 	req, _ := http.NewRequest("GET", url, nil)
@@ -36,6 +36,8 @@ func TestHelpersCDNBackendServerHandlers(t *testing.T) {
 // CDNBackendServer should always respond to HEAD requests in order for the
 // CDN to determine the health of our origin.
 func TestHelpersCDNBackendServerProbes(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("HEAD request incorrectly served by CDNBackendServer.handler")
 	})
@@ -50,7 +52,7 @@ func TestHelpersCDNBackendServerProbes(t *testing.T) {
 }
 
 func TestHelpersCDNServeStop(t *testing.T) {
-	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
+	ResetBackends(backendsByPriority)
 
 	if started := originServer.IsStarted(); started != true {
 		t.Error(
@@ -89,10 +91,4 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	if !re.MatchString(fmt.Sprintf("%s", err)) {
 		t.Errorf("Connection error %q is not as expected", err)
 	}
-
-	// Reset back to a known-good state
-	backupServer1.Stop()
-	backupServer2.Stop()
-	ResetBackends(backendsByPriority)
-
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -78,6 +78,6 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	// Reset back to a known-good state
 	backupServer1.Stop()
 	backupServer2.Stop()
-	StartBackendsInOrder(*edgeHost)
+	StartBackendsInOrder(*edgeHost, backendsByPriority)
 
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -52,6 +52,14 @@ func TestHelpersCDNBackendServerProbes(t *testing.T) {
 func TestHelpersCDNServeStop(t *testing.T) {
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {})
 
+	if started := originServer.IsStarted(); started != true {
+		t.Error(
+			"originServer.IsStarted() incorrect. Expected %q, got %q",
+			true,
+			started,
+		)
+	}
+
 	url := fmt.Sprintf("http://localhost:%d/foo", originServer.Port)
 	req, _ := http.NewRequest("GET", url, nil)
 
@@ -64,6 +72,13 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	}
 
 	originServer.Stop()
+	if started := originServer.IsStarted(); started != false {
+		t.Error(
+			"originServer.IsStarted() incorrect. Expected %q, got %q",
+			false,
+			started,
+		)
+	}
 
 	resp, err = client.RoundTrip(req)
 	if err == nil {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -93,6 +93,6 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	// Reset back to a known-good state
 	backupServer1.Stop()
 	backupServer2.Stop()
-	StartBackendsInOrder(*edgeHost, backendsByPriority)
+	ResetBackends(*edgeHost, backendsByPriority)
 
 }


### PR DESCRIPTION
Rename StartBackendsInOrder() to ResetBackends() and make it responsible for
resetting all backends back to a known good state; started, default handler,
edge considers healthy.

This can be called at the start by init() and then by any tests that modify
the backend state. If no backends have been stopped then it will be quick.

It's not easy to write a test for this because of how much we'd have to mock out with interfaces. But waitForBackend and our other tests will fail if this doesn't work.

---

Pushing what I did on Friday so that someone can write the other failover tests if they fancy. No, I'm not working today. Yes, I'm now closing my laptop.
