### PR TITLE
Fix various go vet warnings

### DIFF
--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -45,7 +45,7 @@ func TestRespHeaderAge(t *testing.T) {
 	resp = RoundTripCheckError(t, req)
 
 	if resp.StatusCode != 200 {
-		t.Fatal("Edge returned an unexpected status: %q", resp.Status)
+		t.Fatalf("Edge returned an unexpected status: %q", resp.Status)
 	}
 
 	edgeAgeHeader := resp.Header.Get("Age")

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -38,7 +38,7 @@ func init() {
 	flag.Parse()
 
 	if *edgeHost == "" {
-		fmt.Println("ERROR: -edgeHost must be set to the CDN edge hostname we wish to test against\n")
+		fmt.Printf("ERROR: -edgeHost must be set to the CDN edge hostname we wish to test against\n\n")
 		fmt.Println("Usage:")
 		flag.PrintDefaults()
 		os.Exit(1)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -54,10 +54,13 @@ func TestHelpersCDNBackendServerProbes(t *testing.T) {
 func TestHelpersCDNServeStop(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	if started := originServer.IsStarted(); started != true {
-		t.Error(
-			"originServer.IsStarted() incorrect. Expected %q, got %q",
-			true,
+	var expectedStarted bool
+
+	expectedStarted = true
+	if started := originServer.IsStarted(); started != expectedStarted {
+		t.Errorf(
+			"originServer.IsStarted() incorrect. Expected %t, got %t",
+			expectedStarted,
 			started,
 		)
 	}
@@ -74,10 +77,11 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	}
 
 	originServer.Stop()
-	if started := originServer.IsStarted(); started != false {
-		t.Error(
-			"originServer.IsStarted() incorrect. Expected %q, got %q",
-			false,
+	expectedStarted = false
+	if started := originServer.IsStarted(); started {
+		t.Errorf(
+			"originServer.IsStarted() incorrect. Expected %t, got %t",
+			expectedStarted,
 			started,
 		)
 	}


### PR DESCRIPTION
- Fix formatting error in TestRespHeaderAge
- Fix "Println call ends with newline"
- Formatting errors in TestHelpersCDNServeStop
