### PR TITLE
[Fixes #60] Verify we're not purging in PURGE test

### DIFF
--- a/cdn_misc_test.go
+++ b/cdn_misc_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -28,22 +29,67 @@ func TestMiscProtocolRedirect(t *testing.T) {
 	}
 }
 
-// Should return 403 for PURGE requests from IPs not in the whitelist. We
-// assume that this is not running from a whitelisted address.
+// Should return 403 and not invalidate the edge's cache for PURGE requests
+// that come from IPs not in the whitelist. We assume that this is not
+// running from a whitelisted address.
 func TestMiscRestrictPurgeRequests(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const expectedStatusCode = 403
-
-	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("Request should not have made it to origin")
-	})
-
+	var expectedBody string
+	var expectedStatus int
 	req := NewUniqueEdgeGET(t)
-	req.Method = "PURGE"
-	resp := RoundTripCheckError(t, req)
 
-	if resp.StatusCode != expectedStatusCode {
-		t.Errorf("Incorrect status code. Expected %d, got %d", expectedStatusCode, resp.StatusCode)
+	for requestCount := 1; requestCount < 4; requestCount++ {
+		switch requestCount {
+		case 1:
+			req.Method = "GET"
+			expectedBody = "this should not be purged"
+			expectedStatus = 200
+
+			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(expectedBody))
+			})
+		case 2:
+			req.Method = "PURGE"
+			expectedBody = ""
+			expectedStatus = 403
+
+			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("Request should not have made it to origin")
+				w.Write([]byte(originServer.Name))
+			})
+		case 3:
+			req.Method = "GET"
+			expectedBody = "this should not be purged"
+			expectedStatus = 200
+		}
+
+		resp := RoundTripCheckError(t, req)
+
+		if resp.StatusCode != expectedStatus {
+			t.Errorf(
+				"Request %d received incorrect status code. Expected %d, got %d",
+				requestCount,
+				expectedStatus,
+				resp.StatusCode,
+			)
+		}
+
+		if expectedBody != "" {
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if bodyStr := string(body); bodyStr != expectedBody {
+				t.Errorf(
+					"Request %d received incorrect response body. Expected %q, got %q",
+					requestCount,
+					expectedBody,
+					bodyStr,
+				)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Improve the PURGE test to verify that we haven't actually purged the object
from edge's cache in addition to receiving the correct response code.

Because that's the actual behaviour we want to protect against and it's
quite conceivable that we could return a response code but still perform the
action.
