### PR TITLE
[Fixes #28] Add tests for Vary headers

### DIFF
--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -84,3 +84,17 @@ func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
 	req := NewUniqueEdgeGET(t)
 	testThreeRequestsNotCached(t, req, handler)
 }
+
+// Should not cache a response with a `Vary: *` header.
+func TestNoCacheHeaderVaryAsterisk(t *testing.T) {
+	t.Skip("Not widely supported")
+
+	ResetBackends(backendsByPriority)
+
+	handler := func(h http.Header) {
+		h.Set("Vary", "*")
+	}
+
+	req := NewUniqueEdgeGET(t)
+	testThreeRequestsNotCached(t, req, handler)
+}


### PR DESCRIPTION
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44
http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.6

Skipped test for `Vary: *`

Varnish didn't always support this. Added in:
varnish/Varnish-Cache@0d31464

However Fastly doesn't, I'm not sure how many other people do, and I'm also
not sure how important it is. So I'm going to add it for completeness with
the RFC but skip it so that it doesn't fail our tests for the moment.
