### PR TITLE
[Fixes #74035678 #62] Split and implement remaining serve stale tests

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -102,9 +102,19 @@ func TestFailoverOrigin5xxBackOff(t *testing.T) {
 	t.Skip("Not implemented")
 }
 
-// Should serve stale object and not hit mirror(s) if origin is down and
-// object is beyond TTL but still in cache.
-func TestFailoverOriginDownServeStale(t *testing.T) {
+// Should serve reponse from first mirror and replace stale object if origin
+// is down and health check has *not* expired.
+// FIXME: This is not desired behaviour. We should serve from stale
+//        immediately and not replace the stale object in cache.
+func TestFailoverOriginDownHealthCheckNotExpiredReplaceStale(t *testing.T) {
+	t.Skip("Not implemented")
+}
+
+// Should serve stale object and not hit mirror(s) if origin is down, health
+// check has expired, and object is beyond TTL but still in cache.
+// FIXME: This is not quite desired behaviour. We should not have to wait
+//				for the stale object to become available.
+func TestFailoverOriginDownHealthCheckHasExpiredServeStale(t *testing.T) {
 	t.Skip("Not implemented")
 }
 

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -107,7 +107,78 @@ func TestFailoverOrigin5xxBackOff(t *testing.T) {
 // FIXME: This is not desired behaviour. We should serve from stale
 //        immediately and not replace the stale object in cache.
 func TestFailoverOriginDownHealthCheckNotExpiredReplaceStale(t *testing.T) {
-	t.Skip("Not implemented")
+	ResetBackends(backendsByPriority)
+
+	const expectedResponseStale = "going off like stilton"
+	const expectedResponseFresh = "as fresh as daisies"
+
+	const respTTL = time.Duration(2 * time.Second)
+	const respTTLWithBuffer = 5 * respTTL
+	headerValue := fmt.Sprintf("max-age=%.0f", respTTL.Seconds())
+
+	backupServer2.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+		name := backupServer2.Name
+		t.Errorf("Server %s received request and it shouldn't have", name)
+		w.Write([]byte(name))
+	})
+
+	req := NewUniqueEdgeGET(t)
+
+	var expectedBody string
+	for requestCount := 1; requestCount < 4; requestCount++ {
+		switch requestCount {
+		case 1: // Request 1 populates cache.
+			expectedBody = expectedResponseStale
+
+			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Cache-Control", headerValue)
+				w.Write([]byte(expectedBody))
+			})
+			backupServer1.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				name := backupServer1.Name
+				t.Errorf("Server %s received request and it shouldn't have", name)
+				w.Write([]byte(name))
+			})
+		case 2: // Request 2 comes from mirror and invalidates stale.
+			time.Sleep(respTTLWithBuffer)
+			expectedBody = expectedResponseFresh
+
+			originServer.Stop()
+			backupServer1.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(expectedBody))
+			})
+		case 3: // Request 3 still comes from cache when origin is back.
+			expectedBody = expectedResponseFresh
+
+			ResetBackends(backendsByPriority)
+			originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				name := originServer.Name
+				t.Errorf("Server %s received request and it shouldn't have", name)
+				w.Write([]byte(name))
+			})
+			backupServer1.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+				name := backupServer1.Name
+				t.Errorf("Server %s received request and it shouldn't have", name)
+				w.Write([]byte(name))
+			})
+		}
+
+		resp := RoundTripCheckError(t, req)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bodyStr := string(body); bodyStr != expectedBody {
+			t.Errorf(
+				"Request %d received incorrect response body. Expected %q, got %q",
+				requestCount,
+				expectedBody,
+				bodyStr,
+			)
+		}
+	}
 }
 
 // Should serve stale object and not hit mirror(s) if origin is down, health

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -190,7 +190,7 @@ func TestFailoverOriginDownHealthCheckHasExpiredServeStale(t *testing.T) {
 
 	const expectedBody = "going off like stilton"
 	// Allow health check to expire. Depends on window/threshold/interval.
-	const healthCheckExpire = time.Duration(15 * time.Second)
+	const healthCheckExpire = time.Duration(20 * time.Second)
 	const respTTL = time.Duration(2 * time.Second)
 	headerValue := fmt.Sprintf("max-age=%.0f", respTTL.Seconds())
 


### PR DESCRIPTION
Because we've realised that the behaviour is different depending on whether
we wait for the health check to mark the backend as down. This was described
in Matt's original varnishtest code:

https://github.gds/gds/fastly-config/blob/177d002bcc33639bbccf61fa52f7809ed4b2d01d/test/feature-tests/serve-from-stale-govuk.vtc#L10-15

Pair w/Cal.
