### PR TITLE
Only cache lookup for *edgeHost address

### DIFF
--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -102,7 +102,7 @@ func HardCachedHostDial(network, addr string) (net.Conn, error) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if host == "localhost" {
+	if host != *edgeHost {
 		return net.Dial(network, addr)
 	}
 	ipAddr := CachedHostIpAddress(host)


### PR DESCRIPTION
Because the hostname of the backend server used by the CDNBackendServer
helper tests isn't always "localhost" - it can be ::1 or 127.0.0.1 - which
results in those addresses being resolved to the same as *edgeHost and this
error occurs:

```
helpers.go:141: dial tcp 172.16.20.10:8080: connection refused
```

We could use a more complex map of cached names and addresses. But I think
edgeHost is the only thing we want to cache.
