### PR TITLE
Use HTTP/1.0 for Varnish probes without Host

### DIFF
--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -2,7 +2,7 @@ backend default {
   .host = "<%= @varnish_backend_address -%>";
   .port = "8080";
   .probe = {
-    .request = "HEAD / HTTP/1.1" "Connection: close";
+    .request = "HEAD / HTTP/1.0" "Connection: close";
     .threshold = 1;
     .window = 2;
     .timeout = 5s;
@@ -16,7 +16,7 @@ backend backup1 {
   .host = "<%= @varnish_backend_address -%>";
   .port = "8081";
   .probe = {
-    .request = "HEAD / HTTP/1.1" "Connection: close";
+    .request = "HEAD / HTTP/1.0" "Connection: close";
     .threshold = 1;
     .window = 2;
     .timeout = 5s;
@@ -30,7 +30,7 @@ backend backup2 {
   .host = "<%= @varnish_backend_address -%>";
   .port = "8082";
   .probe = {
-    .request = "HEAD / HTTP/1.1" "Connection: close";
+    .request = "HEAD / HTTP/1.0" "Connection: close";
     .threshold = 1;
     .window = 2;
     .timeout = 5s;


### PR DESCRIPTION
It's not valid for an HTTP/1.1 request to not have a Host header. So we
should downgrade these requests to HTTP/1.0
