### PR TITLE
[Fixes #51] Allow failover tests to be skipped

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -9,11 +9,20 @@ import (
 	"time"
 )
 
+// checkForSkipFailover skips the calling test if the skipFailover flag has
+// been set.
+func checkForSkipFailover(t *testing.T) {
+	if *skipFailover {
+		t.Skip("Failover tests disabled")
+	}
+}
+
 // Should serve a known static error page if all backend servers are down
 // and object isn't in cache/stale.
 // NB: ideally this should be a page that we control that has a mechanism
 //     to alert us that it has been served.
 func TestFailoverErrorPageAllServersDown(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const expectedStatusCode = http.StatusServiceUnavailable
@@ -52,6 +61,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 // Should return the 5xx response from the last backup server if all
 // preceeding servers also return a 5xx response.
 func TestFailoverErrorPageAllServers5xx(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const expectedStatusCode = http.StatusServiceUnavailable
@@ -99,6 +109,7 @@ func TestFailoverErrorPageAllServers5xx(t *testing.T) {
 // Should back off requests against origin for a very short period of time
 // (so as not to overwhelm it) if origin returns a 5xx response.
 func TestFailoverOrigin5xxBackOff(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const expectedBody = "lucky golden ticket"
@@ -162,6 +173,7 @@ func TestFailoverOrigin5xxBackOff(t *testing.T) {
 // FIXME: This is not desired behaviour. We should serve from stale
 //        immediately and not replace the stale object in cache.
 func TestFailoverOriginDownHealthCheckNotExpiredReplaceStale(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const expectedResponseStale = "going off like stilton"
@@ -241,6 +253,7 @@ func TestFailoverOriginDownHealthCheckNotExpiredReplaceStale(t *testing.T) {
 // FIXME: This is not quite desired behaviour. We should not have to wait
 //				for the stale object to become available.
 func TestFailoverOriginDownHealthCheckHasExpiredServeStale(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const expectedBody = "going off like stilton"
@@ -295,6 +308,7 @@ func TestFailoverOriginDownHealthCheckHasExpiredServeStale(t *testing.T) {
 // Should serve stale object and not hit mirror(s) if origin returns a 5xx
 // response and object is beyond TTL but still in cache.
 func TestFailoverOrigin5xxServeStale(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const expectedResponseStale = "going off like stilton"
@@ -367,6 +381,7 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 // Should fallback to first mirror if origin is down and object is not in
 // cache (active or stale).
 func TestFailoverOriginDownUseFirstMirror(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	expectedBody := "lucky golden ticket"
@@ -410,6 +425,7 @@ func TestFailoverOriginDownUseFirstMirror(t *testing.T) {
 // Should fallback to first mirror if origin returns 5xx response and object
 // is not in cache (active or stale).
 func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	expectedBody := "lucky golden ticket"
@@ -470,6 +486,7 @@ func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
 // Should fallback to second mirror if both origin and first mirror are
 // down.
 func TestFailoverOriginDownFirstMirrorDownUseSecondMirror(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	expectedBody := "lucky golden ticket"
@@ -509,6 +526,7 @@ func TestFailoverOriginDownFirstMirrorDownUseSecondMirror(t *testing.T) {
 // Should fallback to second mirror if both origin and first mirror return
 // 5xx responses.
 func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	expectedBody := "lucky golden ticket"
@@ -575,6 +593,7 @@ func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
 // No-Fallback header. In order to allow applications to present their own
 // error pages.
 func TestFailoverNoFallbackHeader(t *testing.T) {
+	checkForSkipFailover(t)
 	ResetBackends(backendsByPriority)
 
 	const headerName = "No-Fallback"

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -16,6 +16,7 @@ var (
 	originPort    = flag.Int("originPort", 8080, "Origin port to listen on for requests")
 	backupPort1   = flag.Int("backupPort1", 8081, "Backup1 port to listen on for requests")
 	backupPort2   = flag.Int("backupPort2", 8082, "Backup2 port to listen on for requests")
+	skipFailover  = flag.Bool("skipFailover", false, "Skip failover tests and only setup the origin backend")
 	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 )
 
@@ -58,19 +59,24 @@ func init() {
 		Name: "origin",
 		Port: *originPort,
 	}
-	backupServer1 = &CDNBackendServer{
-		Name: "backup1",
-		Port: *backupPort1,
-	}
-	backupServer2 = &CDNBackendServer{
-		Name: "backup2",
-		Port: *backupPort2,
-	}
-
 	backendsByPriority = []*CDNBackendServer{
 		originServer,
-		backupServer1,
-		backupServer2,
+	}
+
+	if !*skipFailover {
+		backupServer1 = &CDNBackendServer{
+			Name: "backup1",
+			Port: *backupPort1,
+		}
+		backupServer2 = &CDNBackendServer{
+			Name: "backup2",
+			Port: *backupPort2,
+		}
+		backendsByPriority = append(
+			backendsByPriority,
+			backupServer1,
+			backupServer2,
+		)
 	}
 
 	log.Println("Confirming that CDN is healthy")


### PR DESCRIPTION
Add a new `-skipFailover` flag that will prevent the additional "backup"
backends from being setup and skips all tests in cdn_failover_test.

I did start an implementation a while ago whereby you could specify a
variable number of backends, but I don't think it's that useful right now.
This is the most efficient thing to do.
