### PR TITLE
Raise an error on slow requests

### DIFF
--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -21,6 +21,7 @@ var (
 
 // These consts and vars are available to all tests.
 const requestTimeout = time.Second * 5
+const requestSlowThreshold = time.Second
 
 var (
 	client             *http.Transport

--- a/helpers.go
+++ b/helpers.go
@@ -123,7 +123,11 @@ func NewUniqueEdgeGET(t *testing.T) *http.Request {
 // or cookies, and return the response. If there are any errors then the
 // calling test will be aborted so as not to operate on a nil response.
 func RoundTripCheckError(t *testing.T, req *http.Request) *http.Response {
+	start := time.Now()
 	resp, err := client.RoundTrip(req)
+	if duration := time.Since(start); duration > requestSlowThreshold {
+		t.Error("Slow request, took:", duration)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Enable TLS on backends.

I'm interested in opinions on the last commit with makes TLS mandatory and introduces stunnel to the mock VM.

This appears to make the tests slower to run against the real CDN provider, but they don't appear to be any more broken: https://github.gds/gist/dancarley/267
