### PR TITLE
Use RawQuery instead of Path for query params

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -107,7 +107,10 @@ func NewUniqueEdgeURL() string {
 	url := url.URL{
 		Scheme: "https",
 		Host:   *edgeHost,
-		Path:   fmt.Sprintf("/?nocache=%s", NewUUID()),
+		Path:   "/",
+		RawQuery: url.Values{
+			"nocache": []string{NewUUID()},
+		}.Encode(),
 	}
 
 	return url.String()


### PR DESCRIPTION
Request query params don't belong in Path. They should go into the RawQuery
field: http://golang.org/pkg/net/url/#URL
