### PR TITLE
More cache feature tests

### DIFF
--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -183,6 +184,65 @@ func TestCacheUniqueQueryParams(t *testing.T) {
 					"Request received wrong %q header. Expected %q, got %q",
 					respHeaderName,
 					req.URL.RawQuery,
+					recVal,
+				)
+			}
+		}
+	}
+}
+
+// Should cache distinct responses for requests with the same query params
+// but paths of different case-sensitivity.
+func TestCacheUniqueCaseSensitive(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	const reqPath = "/CaseSensitive"
+	const respHeaderName = "Request-Path"
+
+	req1 := NewUniqueEdgeGET(t)
+	req2 := NewUniqueEdgeGET(t)
+
+	req1.URL.Path = strings.ToLower(reqPath)
+	req2.URL.Path = strings.ToUpper(reqPath)
+	req1.URL.RawQuery = req2.URL.RawQuery
+
+	if req1.URL.Path == req2.URL.Path {
+		t.Fatalf(
+			"Request paths do not differ. Expected %q != %q",
+			req1.URL.Path,
+			req2.URL.Path,
+		)
+	}
+	if req1.URL.RawQuery != req2.URL.RawQuery {
+		t.Fatalf(
+			"Request query params do not match. Expected %q, got %q",
+			req1.URL.RawQuery,
+			req2.URL.RawQuery,
+		)
+	}
+
+	for _, populateCache := range []bool{true, false} {
+		for _, req := range []*http.Request{req1, req2} {
+			if populateCache {
+				originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set(respHeaderName, r.URL.Path)
+				})
+			} else {
+				originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
+					t.Errorf(
+						"Request with path %q should not have made it to origin",
+						r.URL.Path,
+					)
+				})
+			}
+
+			resp := RoundTripCheckError(t, req)
+
+			if recVal := resp.Header.Get(respHeaderName); recVal != req.URL.Path {
+				t.Errorf(
+					"Request received wrong %q header. Expected %q, got %q",
+					respHeaderName,
+					req.URL.Path,
 					recVal,
 				)
 			}

--- a/helpers.go
+++ b/helpers.go
@@ -107,7 +107,10 @@ func NewUniqueEdgeURL() string {
 	url := url.URL{
 		Scheme: "https",
 		Host:   *edgeHost,
-		Path:   fmt.Sprintf("/?nocache=%s", NewUUID()),
+		Path:   "/",
+		RawQuery: url.Values{
+			"nocache": []string{NewUUID()},
+		}.Encode(),
 	}
 
 	return url.String()


### PR DESCRIPTION
#### Add TestCacheUniqueQueryParams

Per the test comment. This should never happen in Fastly, but Cloudflare
(and Akamai IIRC) have cache configuration level called "basic" that will
disregard the query param as a cache key.

Technically this should be picked up by all of our tests because the helper
uses the same path but different query params for each test. But it's better
to be explicit about it, especially if we change the helper in future. Hence
the additional assertions about req.URL.Path.
#### Add TestCacheUniqueCaseSensitive

Per the test comment. This was a feature that we once enabled in Akamai and
subsequently forgot about; it lead to some very non-deterministic behaviour
and took us a while to pluck up the courage to turn it off. We should
safeguard against this happening again in the future.

I went down a bit of a rabbit-warren trying to figure out how to deep-copy
*http.Request and *url.URL objects with pointer deferences. It turned out to
be much easier to just create two requests and set their respective Path and
RawQuery fields. The first two assertions check that this has actually
worked. The other parts of the request shouldn't matter.
