### PR TITLE
[#76126570] Check for variations on 'Guru Meditation' errors 

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -26,7 +26,10 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
 	const expectedStatusCode = http.StatusServiceUnavailable
-	const expectedBody = "Guru Meditation"
+
+	const expectedBodyFastly = "Guru Mediation"
+	const expectedBodyVarnish = "Guru Meditation"
+	expectedBodies := []string{expectedBodyFastly, expectedBodyVarnish}
 
 	originServer.Stop()
 	backupServer1.Stop()
@@ -49,10 +52,10 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if bodyStr := string(body); !strings.Contains(bodyStr, expectedBody) {
+	if bodyStr := string(body); !stringContainsOneOf(bodyStr, expectedBodies) {
 		t.Errorf(
-			"Received incorrect response body. Expected to contain %q, got %q",
-			expectedBody,
+			"Received incorrect response body. Expected to contain one of %q, got %q",
+			strings.Join(expectedBodies, ", "),
 			bodyStr,
 		)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -347,4 +348,14 @@ func testThreeRequestsNotCached(t *testing.T, req *http.Request, headerCB respon
 			t.Errorf("Incorrect response body. Expected %q, got %q", expectedBody, receivedBody)
 		}
 	}
+}
+
+func stringContainsOneOf(haystack string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Our current CDN vendor, Fastly, currently use a custom error page in which there is a typo. We'd normally expect a 'Guru Meditation' error, but the typo results in a 'Guru Mediation' error.

Work around this by comparing the HTML response body with an array of expected strings.
