### PR TITLE
Fix log message when backend starts with port 0

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +74,12 @@ func (s *CDNBackendServer) Start() {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// Store the port randomly assigned by the kernel if we started with 0.
+	if s.Port == 0 {
+		_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+		s.Port, _ = strconv.Atoi(portStr)
 	}
 
 	s.server = httptest.NewUnstartedServer(s)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -101,6 +101,42 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	}
 }
 
+// CDNBackendServer should assign a random port when started for the first
+// time with a port of 0. Subsequent starts should retain the assigned port
+// from the first start.
+func TestHelpersCDNBackendServerRandomPort(t *testing.T) {
+	const initialPort = 0
+	var assignedPort int
+
+	backend := CDNBackendServer{
+		Name: "test",
+		Port: initialPort,
+	}
+
+	backend.Start()
+	defer backend.Stop()
+
+	assignedPort = backend.Port
+	if assignedPort == initialPort {
+		t.Errorf(
+			"Expected backend port != %d, got %d",
+			initialPort,
+			assignedPort,
+		)
+	}
+
+	backend.Stop()
+	backend.Start()
+
+	if backend.Port != assignedPort {
+		t.Errorf(
+			"Expected backend port == %d, got %d",
+			backend.Port,
+			assignedPort,
+		)
+	}
+}
+
 // CDNBackendServer should use TLS by default as evidenced by an HTTPS URL
 // from `httptest.Server`.
 func TestHelpersCDNBackendServerTLSEnabled(t *testing.T) {


### PR DESCRIPTION
A port value of 0 can be used to let the OS pick an available high-numbered
port. This is handy and we use it in some of our helper tests. But it
results in a strange log message, which @mattbostock asked about:

```
2014/08/01 12:42:37 Started server on port 0
2014/08/01 12:42:37 Started server on port 0
2014/08/01 12:42:37 Started server on port 0
```

Fix this by parsing the assigned port and copying it to s.Port so that the
log line does the right thing again. This now looks like:

```
2014/08/05 15:58:59 Started server on port 57552
2014/08/05 15:58:59 Started server on port 57552
2014/08/05 15:58:59 Started server on port 57555
2014/08/05 15:58:59 Started server on port 57557
2014/08/05 15:58:59 Started server on port 57560
```
