### PR TITLE
Always be callin 'resp.Body.Close()

### DIFF
--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -124,6 +124,7 @@ func TestCacheVary(t *testing.T) {
 
 			req.Header.Set(reqHeaderName, headerVal)
 			resp := RoundTripCheckError(t, req)
+			defer resp.Body.Close()
 
 			if recVal := resp.Header.Get(respHeaderName); recVal != headerVal {
 				t.Errorf(
@@ -178,6 +179,7 @@ func TestCacheUniqueQueryParams(t *testing.T) {
 			}
 
 			resp := RoundTripCheckError(t, req)
+			defer resp.Body.Close()
 
 			if recVal := resp.Header.Get(respHeaderName); recVal != req.URL.RawQuery {
 				t.Errorf(
@@ -237,6 +239,7 @@ func TestCacheUniqueCaseSensitive(t *testing.T) {
 			}
 
 			resp := RoundTripCheckError(t, req)
+			defer resp.Body.Close()
 
 			if recVal := resp.Header.Get(respHeaderName); recVal != req.URL.Path {
 				t.Errorf(

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -37,6 +37,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatusCode {
 		t.Errorf(
@@ -46,7 +47,6 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -85,6 +85,7 @@ func TestFailoverErrorPageAllServers5xx(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatusCode {
 		t.Errorf(
@@ -94,7 +95,6 @@ func TestFailoverErrorPageAllServers5xx(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -145,6 +145,7 @@ func TestFailoverOrigin5xxBackOff(t *testing.T) {
 		}
 
 		resp := RoundTripCheckError(t, req)
+		defer resp.Body.Close()
 
 		if resp.StatusCode != expectedStatus {
 			t.Errorf(
@@ -155,7 +156,6 @@ func TestFailoverOrigin5xxBackOff(t *testing.T) {
 			)
 		}
 
-		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -234,8 +234,8 @@ func TestFailoverOriginDownHealthCheckNotExpiredReplaceStale(t *testing.T) {
 		}
 
 		resp := RoundTripCheckError(t, req)
-
 		defer resp.Body.Close()
+
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -291,8 +291,8 @@ func TestFailoverOriginDownHealthCheckHasExpiredServeStale(t *testing.T) {
 		}
 
 		resp := RoundTripCheckError(t, req)
-
 		defer resp.Body.Close()
+
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -364,8 +364,8 @@ func TestFailoverOrigin5xxServeStale(t *testing.T) {
 		}
 
 		resp := RoundTripCheckError(t, req)
-
 		defer resp.Body.Close()
+
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -402,6 +402,7 @@ func TestFailoverOriginDownUseFirstMirror(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
@@ -411,7 +412,6 @@ func TestFailoverOriginDownUseFirstMirror(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -463,6 +463,7 @@ func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
@@ -472,7 +473,6 @@ func TestFailoverOrigin5xxUseFirstMirror(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -503,6 +503,7 @@ func TestFailoverOriginDownFirstMirrorDownUseSecondMirror(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
@@ -512,7 +513,6 @@ func TestFailoverOriginDownFirstMirrorDownUseSecondMirror(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -569,6 +569,7 @@ func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
@@ -578,7 +579,6 @@ func TestFailoverOrigin5xxFirstMirror5xxUseSecondMirror(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -621,6 +621,7 @@ func TestFailoverNoFallbackHeader(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatus {
 		t.Errorf(
@@ -630,7 +631,6 @@ func TestFailoverNoFallbackHeader(t *testing.T) {
 		)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)

--- a/cdn_misc_test.go
+++ b/cdn_misc_test.go
@@ -31,6 +31,7 @@ func TestMiscProtocolRedirect(t *testing.T) {
 	}
 
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	req.URL.Scheme = expectedProto
 	expectedURL = req.URL.String()
@@ -87,6 +88,7 @@ func TestMiscRestrictPurgeRequests(t *testing.T) {
 		}
 
 		resp := RoundTripCheckError(t, req)
+		defer resp.Body.Close()
 
 		if resp.StatusCode != expectedStatus {
 			t.Errorf(
@@ -98,7 +100,6 @@ func TestMiscRestrictPurgeRequests(t *testing.T) {
 		}
 
 		if expectedBody != "" {
-			defer resp.Body.Close()
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -22,6 +22,7 @@ func TestNoCacheNewRequestOrigin(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", sourceUrl, nil)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		t.Errorf("Status code expected 200, got %d", resp.StatusCode)

--- a/cdn_req_headers_test.go
+++ b/cdn_req_headers_test.go
@@ -24,7 +24,8 @@ func TestReqHeaderXFFCreateAndAppend(t *testing.T) {
 
 	// First request with no existing XFF.
 	req := NewUniqueEdgeGET(t)
-	_ = RoundTripCheckError(t, req)
+	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if receivedHeaderVal == "" {
 		t.Fatalf("Origin didn't receive request with %q header", headerName)
@@ -45,7 +46,9 @@ func TestReqHeaderXFFCreateAndAppend(t *testing.T) {
 	// Second request with existing XFF.
 	req = NewUniqueEdgeGET(t)
 	req.Header.Set(headerName, sentHeaderVal)
-	_ = RoundTripCheckError(t, req)
+
+	resp = RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if receivedHeaderVal != expectedHeaderVal {
 		t.Errorf(
@@ -73,7 +76,9 @@ func TestReqHeaderUnspoofableClientIP(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	req.Header.Set(headerName, sentHeaderVal)
-	_ = RoundTripCheckError(t, req)
+
+	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	receivedHeaderIP := net.ParseIP(receivedHeaderVal)
 	if receivedHeaderIP == nil {
@@ -106,7 +111,8 @@ func TestReqHeaderHostUnmodified(t *testing.T) {
 		)
 	}
 
-	_ = RoundTripCheckError(t, req)
+	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if receivedHeaderVal != sentHeaderVal {
 		t.Errorf(

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -35,6 +35,7 @@ func TestRespHeaderAge(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		t.Fatalf("Edge returned an unexpected status: %q", resp.Status)
@@ -43,6 +44,7 @@ func TestRespHeaderAge(t *testing.T) {
 	// wait a little bit. Edge should update the Age header, we know Origin will not
 	time.Sleep(time.Duration(secondsToWaitBetweenRequests) * time.Second)
 	resp = RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		t.Fatalf("Edge returned an unexpected status: %q", resp.Status)
@@ -85,6 +87,7 @@ func TestRespHeaderXCacheAppend(t *testing.T) {
 	// Get first request, will come from origin, cannot be cached - hence cache MISS
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	xCache = resp.Header.Get("X-Cache")
 	expectedXCache = fmt.Sprintf("%s, MISS", originXCache)
@@ -111,6 +114,7 @@ func TestRespHeaderXCacheCreate(t *testing.T) {
 	// Get first request, will come from origin, cannot be cached - hence cache MISS
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	xCache = resp.Header.Get("X-Cache")
 	if xCache != expectedXCache {
@@ -131,6 +135,7 @@ func TestRespHeaderXServedBy(t *testing.T) {
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	actualHeader := resp.Header.Get("X-Served-By")
 	if actualHeader == "" {
@@ -169,6 +174,7 @@ func TestRespHeaderXCacheHitsAppend(t *testing.T) {
 	// Get first request, will come from origin. Edge Hit Count 0
 	req, _ := http.NewRequest("GET", sourceUrl, nil)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	xCacheHits = resp.Header.Get("X-Cache-Hits")
 	expectedXCacheHits = fmt.Sprintf("%s, 0", originXCacheHits)
@@ -182,6 +188,7 @@ func TestRespHeaderXCacheHitsAppend(t *testing.T) {
 
 	// Get request again. Should come from Edge now, hit count 1
 	resp = RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	xCacheHits = resp.Header.Get("X-Cache-Hits")
 	expectedXCacheHits = fmt.Sprintf("%s, 1", originXCacheHits)

--- a/helpers.go
+++ b/helpers.go
@@ -201,17 +201,22 @@ func waitForBackend(expectedBackendName string) error {
 	for try := 0; try <= maxRetries; try++ {
 		url = NewUniqueEdgeURL()
 		req, _ := http.NewRequest("GET", url, nil)
+
 		resp, err := client.RoundTrip(req)
 		if err != nil {
 			return err
 		}
+		resp.Body.Close()
+
 		if resp.Header.Get("Backend-Name") == expectedBackendName {
 			if try != 0 {
 				time.Sleep(waitForCdnProbeToPropagate)
 			}
+
 			log.Println(expectedBackendName + " is up!")
 			return nil // all is well!
 		}
+
 		time.Sleep(timeBetweenAttempts)
 	}
 
@@ -281,8 +286,8 @@ func testRequestsCachedDuration(t *testing.T, respCB responseCallback, respTTL t
 		}
 
 		resp := RoundTripCheckError(t, req)
-
 		defer resp.Body.Close()
+
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -337,8 +342,8 @@ func testThreeRequestsNotCached(t *testing.T, req *http.Request, headerCB respon
 
 	for _, expectedBody := range responseBodies {
 		resp := RoundTripCheckError(t, req)
-
 		defer resp.Body.Close()
+
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -20,6 +20,7 @@ func TestHelpersCDNBackendServerHandlers(t *testing.T) {
 	url := originServer.server.URL + "/" + NewUUID()
 	req, _ := http.NewRequest("GET", url, nil)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		t.Error("First request to default handler failed")
@@ -31,6 +32,8 @@ func TestHelpersCDNBackendServerHandlers(t *testing.T) {
 		})
 
 		resp := RoundTripCheckError(t, req)
+		defer resp.Body.Close()
+
 		if resp.StatusCode != statusCode {
 			t.Errorf("SwitchHandler didn't work. Got %d, expected %d", resp.StatusCode, statusCode)
 		}
@@ -49,6 +52,7 @@ func TestHelpersCDNBackendServerProbes(t *testing.T) {
 	url := originServer.server.URL + "/"
 	req, _ := http.NewRequest("HEAD", url, nil)
 	resp := RoundTripCheckError(t, req)
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 || resp.Header.Get("PING") != "PONG" {
 		t.Error("HEAD request for '/' served incorrectly")
@@ -76,6 +80,8 @@ func TestHelpersCDNServeStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		t.Error("originServer should be up and responding, prior to Stop operation")
 	}
@@ -92,6 +98,7 @@ func TestHelpersCDNServeStop(t *testing.T) {
 
 	resp, err = client.RoundTrip(req)
 	if err == nil {
+		defer resp.Body.Close()
 		t.Error("Client connection succeeded. The server should be refusing requests by now.")
 	}
 


### PR DESCRIPTION
The response bodies needs to be closed regardless of whether we read it or
not. Always defer this immediately after calling RoundTripCheckError().

Except for waitForBackend() where we loop several times and don't want to
wait until the end to close all of the bodies.
