### PR TITLE
Add TestNoCacheHeaderCacheControlMaxAge0

### DIFF
--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -85,6 +85,18 @@ func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
 	testThreeRequestsNotCached(t, req, handler)
 }
 
+// Should not cache a response with a `Cache-Control: max-age=0` header.
+func TestNoCacheHeaderCacheControlMaxAge0(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	handler := func(h http.Header) {
+		h.Set("Cache-Control", "max-age=0")
+	}
+
+	req := NewUniqueEdgeGET(t)
+	testThreeRequestsNotCached(t, req, handler)
+}
+
 // Should not cache a response with a `Vary: *` header.
 func TestNoCacheHeaderVaryAsterisk(t *testing.T) {
 	t.Skip("Not widely supported")


### PR DESCRIPTION
The response should not be cached.

It works as expected on Varnish and CloudFlare. It mostly fails on Fastly,
but I'm not sure that our tests match any of the criteria in this
explanation: http://docs.fastly.com/guides/22951283/26628787

> If you just set max-age=0 or an Expires in the past, there is still no
> guarantee that the content won't be used to satisfy multiple outstanding
> requests at the same time. Also, an expired (stale) object might be used in
> case of errors or while a request to your backend for the same object is
> already in progress.

If we merge this and decide that it's the correct behaviour then we should
create a bug in Pivotal to track any changes required for our Fastly
configs.
