### PR TITLE
[#76066342] Move CC no-(store|cache) from Cache to NoCache

### DIFF
--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -67,30 +67,6 @@ func TestCacheExpiresAndMaxAge(t *testing.T) {
 	testRequestsCachedDuration(t, handler, cacheDuration)
 }
 
-// Should cache responses with a `Cache-Control: no-cache` header. Varnish
-// doesn't respect this by default.
-func TestCacheCacheControlNoCache(t *testing.T) {
-	ResetBackends(backendsByPriority)
-
-	handler := func(w http.ResponseWriter) {
-		w.Header().Set("Cache-Control", "no-cache")
-	}
-
-	testRequestsCachedIndefinite(t, handler)
-}
-
-// Should cache responses with a `Cache-Control: no-store` header. Varnish
-// doesn't respect this by default.
-func TestCacheCacheControlNoStore(t *testing.T) {
-	ResetBackends(backendsByPriority)
-
-	handler := func(w http.ResponseWriter) {
-		w.Header().Set("Cache-Control", "no-store")
-	}
-
-	testRequestsCachedIndefinite(t, handler)
-}
-
 // Should cache responses with a status code of 404. It's a common
 // misconception that 404 responses shouldn't be cached; they should because
 // they can be expensive to generate.

--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -79,6 +79,18 @@ func TestCacheCacheControlNoCache(t *testing.T) {
 	testRequestsCachedIndefinite(t, handler)
 }
 
+// Should cache responses with a `Cache-Control: no-store` header. Varnish
+// doesn't respect this by default.
+func TestCacheCacheControlNoStore(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	handler := func(w http.ResponseWriter) {
+		w.Header().Set("Cache-Control", "no-store")
+	}
+
+	testRequestsCachedIndefinite(t, handler)
+}
+
 // Should cache responses with a status code of 404. It's a common
 // misconception that 404 responses shouldn't be cached; they should because
 // they can be expensive to generate.

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -74,6 +74,32 @@ func TestNoCacheHeaderSetCookie(t *testing.T) {
 	testThreeRequestsNotCached(t, req, handler)
 }
 
+// Should not cache responses with a `Cache-Control: no-cache` header.
+// Varnish doesn't respect this by default.
+func TestNoCacheCacheControlNoCache(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	handler := func(h http.Header) {
+		h.Set("Cache-Control", "no-cache")
+	}
+
+	req := NewUniqueEdgeGET(t)
+	testThreeRequestsNotCached(t, req, handler)
+}
+
+// Should not cache responses with a `Cache-Control: no-store` header.
+// Varnish doesn't respect this by default.
+func TestNoCacheCacheControlNoStore(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	handler := func(h http.Header) {
+		h.Set("Cache-Control", "no-store")
+	}
+
+	req := NewUniqueEdgeGET(t)
+	testThreeRequestsNotCached(t, req, handler)
+}
+
 // Should not cache a response with a `Cache-Control: private` header.
 func TestNoCacheHeaderCacheControlPrivate(t *testing.T) {
 	ResetBackends(backendsByPriority)

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -91,6 +91,10 @@ sub vcl_fetch {
   if (beresp.http.Cache-Control ~ "private") {
     return (hit_for_pass);
   }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (hit_for_pass);
+  }
 }
 
 sub vcl_deliver {


### PR DESCRIPTION
The mocks have been adjusted in the previous commit. These tests now pass on
CloudFlare by default. We'll need to adjust our Fastly configs, which I
think is probably the right direction to go.

---

Also adds a new test and mock.
