### PR TITLE
Allow jenkins to skip failover tests

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -5,5 +5,8 @@ if [ "$TEST_VERIFYTLS" = "yes" ]; then
 else
     export TEST_ARGS="-skipVerifyTLS";
 fi
+if [ "$TEST_FAILOVER" = "no" ]; then
+    export TEST_ARGS="${TEST_ARGS} -skipFailover"
+fi
 echo "Running: go test -edgeHost $TEST_EDGEHOST $TEST_ARGS"
 go test -edgeHost $TEST_EDGEHOST $TEST_ARGS


### PR DESCRIPTION
This is necessary to test the Cloudflare config
