### PR TITLE
Add -debugResp flag for logging responses

### DIFF
--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -20,6 +20,9 @@ var (
 	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 	backendCert   = flag.String("backendCert", "", "Override self-signed cert for backend TLS")
 	backendKey    = flag.String("backendKey", "", "Override self-signed cert, must be provided with -backendCert")
+	// This only works with tests that use RoundTripCheckError(), that either
+	// are either failing or run with the -v flag.
+	debugResp     = flag.Bool("debugResp", false, "Log responses for debugging")
 )
 
 // These consts and vars are available to all tests.

--- a/helpers.go
+++ b/helpers.go
@@ -147,6 +147,9 @@ func RoundTripCheckError(t *testing.T, req *http.Request) *http.Response {
 	if duration := time.Since(start); duration > requestSlowThreshold {
 		t.Error("Slow request, took:", duration)
 	}
+	if *debugResp {
+		t.Logf("%#v", resp)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This will log all responses (including nil objects). I'm using this to debug
some broken tests, which appear to have the wrong response headers. It's
quite noisy though so you wouldn't want to use it all the time.
