### PR TITLE
Allow "connection refused" errors from helper

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -58,6 +58,7 @@ func TestHelpersCDNBackendServerProbes(t *testing.T) {
 func TestHelpersCDNServeStop(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
+	var connectionErrorRegex *regexp.Regexp = regexp.MustCompile(`(^EOF| connection refused)$`)
 	var expectedStarted bool
 
 	expectedStarted = true
@@ -95,8 +96,7 @@ func TestHelpersCDNServeStop(t *testing.T) {
 		t.Error("Client connection succeeded. The server should be refusing requests by now.")
 	}
 
-	re := regexp.MustCompile(`EOF`)
-	if !re.MatchString(fmt.Sprintf("%s", err)) {
+	if !connectionErrorRegex.MatchString(fmt.Sprintf("%s", err)) {
 		t.Errorf("Connection error %q is not as expected", err)
 	}
 }


### PR DESCRIPTION
Very occasionally the helper test will fail with "connection refused"
instead of "EOF". As seen here:

https://ci-new.alphagov.co.uk/job/govuk_infrastructure_cdn-acceptance-test_cloudflare/15/console

I suspect this happens when the connection is reset during the intial TCP
setup (dial) rather than in the middle of a request. This is similar to:

https://github.com/alphagov/govuk_crawler_worker/commit/fdde4d1723866be44e4fc054765024a120f904df#diff-2cad8ba8c8780d07a5167b083d6a0cb8R62

So match both errors. But without the complexity of a type assertion.
