### PR TITLE
[#75804242] Add flag to print usage information 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ To run a subset of tests based on a regex:
 go test -run 'Test(Cache|NoCache)'
 ```
 
+To see all available command-line options:
+```sh
+go test -usage
+```
+
 ## Writing tests
 
 When writing new tests please be sure to:

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -20,6 +20,7 @@ var (
 	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 	backendCert   = flag.String("backendCert", "", "Override self-signed cert for backend TLS")
 	backendKey    = flag.String("backendKey", "", "Override self-signed cert, must be provided with -backendCert")
+	usage         = flag.Bool("usage", false, "Print usage")
 	// This only works with tests that use RoundTripCheckError(), that either
 	// are either failing or run with the -v flag.
 	debugResp     = flag.Bool("debugResp", false, "Log responses for debugging")
@@ -43,6 +44,11 @@ var hardCachedEdgeHostIp string
 func init() {
 
 	flag.Parse()
+
+	if *usage {
+		flag.Usage()
+		os.Exit(0)
+	}
 
 	if *edgeHost == "" {
 		fmt.Printf("ERROR: -edgeHost must be set to the CDN edge hostname we wish to test against\n\n")

--- a/common_setup_test.go
+++ b/common_setup_test.go
@@ -46,8 +46,7 @@ func init() {
 
 	if *edgeHost == "" {
 		fmt.Printf("ERROR: -edgeHost must be set to the CDN edge hostname we wish to test against\n\n")
-		fmt.Println("Usage:")
-		flag.PrintDefaults()
+		flag.Usage()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
The `-help` flag is overridden by `go test` and doesn't display the available flags, so add a new `-usage` flag that displays usage information (including flags).

---

Also, use the default usage function when `-edgeHost` is supplied with an empty string.
