### PR TITLE
[#75803512] Check for Cloudflare CF-RAY header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ brew install go
 
 To run all the tests:
 ```sh
-go test
+go test -edgeHost cdn-vendor.example.com
 ```
+
+...where `-edgeHost` specifies the CDN edge.
 
 To run a subset of tests based on a regex:
 ```sh
-go test -run 'Test(Cache|NoCache)'
+go test -edgeHost cdn-vendor.example.com -run 'Test(Cache|NoCache)'
 ```
 
 To see all available command-line options:

--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -26,10 +26,14 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
 	const expectedStatusCode = http.StatusServiceUnavailable
+	var expectedBody string
 
-	const expectedBodyFastly = "Guru Mediation"
-	const expectedBodyVarnish = "Guru Meditation"
-	expectedBodies := []string{expectedBodyFastly, expectedBodyVarnish}
+	switch {
+	case vendorFastly:
+		expectedBody = "Guru Mediation"
+	default:
+		expectedBody = "Guru Meditation"
+	}
 
 	originServer.Stop()
 	backupServer1.Stop()
@@ -52,10 +56,10 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if bodyStr := string(body); !stringContainsOneOf(bodyStr, expectedBodies) {
+	if bodyStr := string(body); !strings.Contains(bodyStr, expectedBody) {
 		t.Errorf(
-			"Received incorrect response body. Expected to contain one of %q, got %q",
-			strings.Join(expectedBodies, ", "),
+			"Received incorrect response body. Expected to contain %q, got %q",
+			expectedBody,
 			bodyStr,
 		)
 	}

--- a/cdn_req_headers_test.go
+++ b/cdn_req_headers_test.go
@@ -85,9 +85,7 @@ func TestReqHeaderUnspoofableClientIP(t *testing.T) {
 	var receivedHeaderVal string
 
 	switch {
-	case vendorCloudflare:
-		t.Skip(notSupportedByVendor)
-	case vendorFastly:
+	case vendorCloudflare, vendorFastly:
 		headerName = "True-Client-IP"
 	default:
 		t.Fatal(notImplementedForVendor)

--- a/cdn_req_headers_test.go
+++ b/cdn_req_headers_test.go
@@ -86,9 +86,11 @@ func TestReqHeaderUnspoofableClientIP(t *testing.T) {
 
 	switch {
 	case vendorCloudflare:
-		t.skip(skipVendorMsg)
-	default:
+		t.Skip(notSupportedByVendor)
+	case vendorFastly:
 		headerName = "True-Client-IP"
+	default:
+		t.Fatal(notImplementedForVendor)
 	}
 
 	sentHeaderIP := net.ParseIP(sentHeaderVal)

--- a/cdn_req_headers_test.go
+++ b/cdn_req_headers_test.go
@@ -80,10 +80,18 @@ func TestReqHeaderXFFCreateAndAppend(t *testing.T) {
 func TestReqHeaderUnspoofableClientIP(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const headerName = "True-Client-IP"
 	const sentHeaderVal = "203.0.113.99"
-	var sentHeaderIP = net.ParseIP(sentHeaderVal)
+	var headerName string
 	var receivedHeaderVal string
+
+	switch {
+	case vendorCloudflare:
+		t.skip(skipVendorMsg)
+	default:
+		headerName = "True-Client-IP"
+	}
+
+	sentHeaderIP := net.ParseIP(sentHeaderVal)
 
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		receivedHeaderVal = r.Header.Get(headerName)

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -135,10 +135,10 @@ func TestRespHeaderServedBy(t *testing.T) {
 	var headerName string
 
 	switch {
-	case testForCloudflare:
+	case vendorCloudflare:
 		headerName = "CF-RAY"
 		expectedServedByRegexp = regexp.MustCompile("^[a-z0-9]{16}-[A-Z]{3}$")
-	case testForFastly:
+	case vendorFastly:
 		headerName = "X-Served-By"
 		expectedServedByRegexp = regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
 	default:

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -142,7 +142,7 @@ func TestRespHeaderServedBy(t *testing.T) {
 		headerName = "X-Served-By"
 		expectedServedByRegexp = regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
 	default:
-		t.Skip(skipVendorMsg)
+		t.Fatal(notImplementedForVendor)
 	}
 
 	req := NewUniqueEdgeGET(t)

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -127,23 +127,36 @@ func TestRespHeaderXCacheCreate(t *testing.T) {
 
 }
 
-// Should set an X-Served-By header giving information on the (Fastly) node and location served from.
-func TestRespHeaderXServedBy(t *testing.T) {
+// Should set an 'Served-By' header giving information on the edge node and location served from.
+func TestRespHeaderServedBy(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	expectedFastlyXServedByRegexp := regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
+	var expectedServedByRegexp *regexp.Regexp
+	var headerName string
+
+	switch {
+	case testForCloudflare:
+		headerName = "CF-RAY"
+		expectedServedByRegexp = regexp.MustCompile("^[a-z0-9]{16}-[A-Z]{3}$")
+	case testForFastly:
+		headerName = "X-Served-By"
+		expectedServedByRegexp = regexp.MustCompile("^cache-[a-z0-9]+-[A-Z]{3}$")
+	default:
+		t.Skip(skipVendorMsg)
+	}
 
 	req := NewUniqueEdgeGET(t)
 	resp := RoundTripCheckError(t, req)
 	defer resp.Body.Close()
 
-	actualHeader := resp.Header.Get("X-Served-By")
+	actualHeader := resp.Header.Get(headerName)
+
 	if actualHeader == "" {
-		t.Error("X-Served-By header has not been set by Edge")
+		t.Error(headerName + " header has not been set by Edge")
 	}
 
-	if expectedFastlyXServedByRegexp.FindString(actualHeader) != actualHeader {
-		t.Errorf("X-Served-By is not as expected: got %q", actualHeader)
+	if expectedServedByRegexp.FindString(actualHeader) != actualHeader {
+		t.Errorf("%s is not as expected: got %q", headerName, actualHeader)
 	}
 
 }

--- a/helpers.go
+++ b/helpers.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 )
@@ -369,14 +368,4 @@ func testThreeRequestsNotCached(t *testing.T, req *http.Request, headerCB respon
 			)
 		}
 	}
-}
-
-func stringContainsOneOf(haystack string, needles []string) bool {
-	for _, needle := range needles {
-		if strings.Contains(haystack, needle) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -28,8 +28,8 @@ var (
 )
 
 var (
-	testForFastly     bool = false
-	testForCloudflare bool = false
+	vendorFastly     bool = false
+	vendorCloudflare bool = false
 )
 
 // These consts and vars are available to all tests.
@@ -65,9 +65,9 @@ func init() {
 
 	switch *vendor {
 	case "cloudflare":
-		testForCloudflare = true
+		vendorCloudflare = true
 	case "fastly":
-		testForFastly = true
+		vendorFastly = true
 	case "":
 		log.Println("No vendor specified; running generic tests only")
 	default:

--- a/main_test.go
+++ b/main_test.go
@@ -35,7 +35,8 @@ var (
 // These consts and vars are available to all tests.
 const requestTimeout = time.Second * 5
 const requestSlowThreshold = time.Second
-const skipVendorMsg = "Skipping test; not applicable to your selected vendor"
+const notImplementedForVendor = "Test not yet implemented for your selected vendor or no vendor specified"
+const notSupportedByVendor = "Feature not supported by your selected vendor"
 
 var (
 	client             *http.Transport
@@ -69,7 +70,7 @@ func init() {
 	case "fastly":
 		vendorFastly = true
 	case "":
-		log.Println("No vendor specified; running generic tests only")
+		log.Println("No vendor specified")
 	default:
 		log.Fatalf("Vendor %q unrecognised; aborting", *vendor)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,7 @@ var (
 // These consts and vars are available to all tests.
 const requestTimeout = time.Second * 5
 const requestSlowThreshold = time.Second
+const skipVendorMsg = "Skipping test; not applicable to your selected vendor"
 
 var (
 	client             *http.Transport

--- a/main_test.go
+++ b/main_test.go
@@ -12,18 +12,18 @@ import (
 )
 
 var (
-	edgeHost      = flag.String("edgeHost", "", "Hostname of edge")
-	originPort    = flag.Int("originPort", 8080, "Origin port to listen on for requests")
-	backupPort1   = flag.Int("backupPort1", 8081, "Backup1 port to listen on for requests")
-	backupPort2   = flag.Int("backupPort2", 8082, "Backup2 port to listen on for requests")
-	skipFailover  = flag.Bool("skipFailover", false, "Skip failover tests and only setup the origin backend")
-	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 	backendCert   = flag.String("backendCert", "", "Override self-signed cert for backend TLS")
 	backendKey    = flag.String("backendKey", "", "Override self-signed cert, must be provided with -backendCert")
+	backupPort1   = flag.Int("backupPort1", 8081, "Backup1 port to listen on for requests")
+	backupPort2   = flag.Int("backupPort2", 8082, "Backup2 port to listen on for requests")
+	edgeHost      = flag.String("edgeHost", "", "Hostname of edge")
+	originPort    = flag.Int("originPort", 8080, "Origin port to listen on for requests")
+	skipFailover  = flag.Bool("skipFailover", false, "Skip failover tests and only setup the origin backend")
+	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 	usage         = flag.Bool("usage", false, "Print usage")
 	// This only works with tests that use RoundTripCheckError(), that either
 	// are either failing or run with the -v flag.
-	debugResp     = flag.Bool("debugResp", false, "Log responses for debugging")
+	debugResp = flag.Bool("debugResp", false, "Log responses for debugging")
 )
 
 // These consts and vars are available to all tests.

--- a/main_test.go
+++ b/main_test.go
@@ -21,9 +21,15 @@ var (
 	skipFailover  = flag.Bool("skipFailover", false, "Skip failover tests and only setup the origin backend")
 	skipVerifyTLS = flag.Bool("skipVerifyTLS", false, "Skip TLS cert verification if set")
 	usage         = flag.Bool("usage", false, "Print usage")
+	vendor        = flag.String("vendor", "", "Name of vendor; run tests specific to vendor")
 	// This only works with tests that use RoundTripCheckError(), that either
 	// are either failing or run with the -v flag.
 	debugResp = flag.Bool("debugResp", false, "Log responses for debugging")
+)
+
+var (
+	testForFastly     bool = false
+	testForCloudflare bool = false
 )
 
 // These consts and vars are available to all tests.
@@ -54,6 +60,17 @@ func init() {
 		fmt.Printf("ERROR: -edgeHost must be set to the CDN edge hostname we wish to test against\n\n")
 		flag.Usage()
 		os.Exit(1)
+	}
+
+	switch *vendor {
+	case "cloudflare":
+		testForCloudflare = true
+	case "fastly":
+		testForFastly = true
+	case "":
+		log.Println("No vendor specified; running generic tests only")
+	default:
+		log.Fatalf("Vendor %q unrecognised; aborting", *vendor)
 	}
 
 	tlsOptions := &tls.Config{}

--- a/main_test.go
+++ b/main_test.go
@@ -33,10 +33,10 @@ var (
 )
 
 // These consts and vars are available to all tests.
-const requestTimeout = time.Second * 5
-const requestSlowThreshold = time.Second
 const notImplementedForVendor = "Test not yet implemented for your selected vendor or no vendor specified"
 const notSupportedByVendor = "Feature not supported by your selected vendor"
+const requestSlowThreshold = time.Second
+const requestTimeout = time.Second * 5
 
 var (
 	client             *http.Transport

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -141,7 +141,7 @@ sub vcl_error {
      set obj.status = 301;
      set obj.response = "Moved Permanently";
      set obj.http.Location = "https://" + req.http.host + req.url;
-     synthetic {""};
+     synthetic "";
      return (deliver);
   }
 

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -144,4 +144,27 @@ sub vcl_error {
      synthetic {""};
      return (deliver);
   }
+
+  # Supply a built-in error page with an intentional typo;
+  # 'Guru Mediation' (sic) to match Fastly's error page
+  set obj.http.Content-Type = "text/html; charset=utf-8";
+  synthetic {"
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+  <head>
+    <title>"} + obj.status + " " + obj.response + {"</title>
+  </head>
+  <body>
+    <h1>Error "} + obj.status + " " + obj.response + {"</h1>
+    <p>"} + obj.response + {"</p>
+    <h3>Guru Mediation:</h3>
+    <p>XID: "} + req.xid + {"</p>
+    <hr>
+    <p>Varnish cache server</p>
+  </body>
+</html>
+"};
+  return (deliver);
 }

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -7,4 +7,4 @@ sudo FACTER_varnish_backend_address="127.0.0.1" \
   --modulepath mock_cdn_config/modules \
   mock_cdn_config/manifests/site.pp || [ $? -eq 2 ]
 
-go test -edgeHost 127.0.0.1 -skipVerifyTLS -v
+go test -edgeHost 127.0.0.1 -skipVerifyTLS -v -vendor=fastly


### PR DESCRIPTION
Add a flag to run tests specific to a vendor, and use that flag to support Cloudflare's `CF-RAY` header that is equivalent to `X-Served-By`.

I have also feature-flagged the existing Fastly-specific tests to run only if `-vendor=fastly` is set.

I also now intentionally cause a test to fail if it has not been adapted for a specified vendor. If a feature is known not to be supported by a vendor, we skip the test. This means that adding new CDN vendors will show failures until the tests are adapted for the new vendor (or the configuration at vendor is corrected).

This also means we're now specifying Fastly as the vendor when we run the mock tests; this is because the Varnish behaviour as-is closely mimics Fastly. We can look at mimicking other vendors using the Varnish mock instance in future.
