### PR TITLE
[#75803332] Add support for Cloudflare's CF-Cache-Status

### DIFF
--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -110,9 +110,8 @@ func TestRespHeaderCacheHitMiss(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
 	var (
-		expectedVal string
 		headerName  string
-		headerVal   string
+		headerValue string
 	)
 
 	switch {
@@ -124,37 +123,27 @@ func TestRespHeaderCacheHitMiss(t *testing.T) {
 		t.Fatal(notImplementedForVendor)
 	}
 
-	// Get first request, will come from origin, cannot be cached - hence cache MISS
+	expectedHeaderValues := []string{"MISS", "HIT"}
+	const cacheDuration = time.Second
+
 	req := NewUniqueEdgeGET(t)
-	resp := RoundTripCheckError(t, req)
-	defer resp.Body.Close()
 
-	expectedVal = "MISS"
-	headerVal = resp.Header.Get(headerName)
+	for count, expectedValue := range expectedHeaderValues {
 
-	if headerVal != expectedVal {
-		t.Errorf(
-			"%s on initial hit is wrong: expected %q, got %q",
-			headerName,
-			expectedVal,
-			headerVal,
-		)
-	}
+		resp := RoundTripCheckError(t, req)
+		defer resp.Body.Close()
 
-	// Get request again. Should come from Edge now and result in a cache HIT
-	resp = RoundTripCheckError(t, req)
-	defer resp.Body.Close()
+		headerValue = resp.Header.Get(headerName)
 
-	expectedVal = "HIT"
-	headerVal = resp.Header.Get(headerName)
-
-	if headerVal != expectedVal {
-		t.Errorf(
-			"%s on second request is wrong: expected %q, got %q",
-			headerName,
-			expectedVal,
-			headerVal,
-		)
+		if headerValue != expectedValue {
+			t.Errorf(
+				"%s on request %d is wrong: expected %q, got %q",
+				headerName,
+				count+1,
+				expectedValue,
+				headerValue,
+			)
+		}
 	}
 }
 

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -127,7 +127,7 @@ func TestRespHeaderCacheHitMiss(t *testing.T) {
 	const cacheDuration = time.Second
 
 	if vendorCloudflare {
-		cloudFlareStatuses := []string{"EXPIRED"}
+		cloudFlareStatuses := []string{"EXPIRED", "HIT"}
 		expectedHeaderValues = append(expectedHeaderValues, cloudFlareStatuses...)
 	}
 

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -127,7 +127,8 @@ func TestRespHeaderCacheHitMiss(t *testing.T) {
 	const cacheDuration = time.Second
 
 	if vendorCloudflare {
-		expectedHeaderValues = append(expectedHeaderValues, "EXPIRED")
+		cloudFlareStatuses := []string{"EXPIRED"}
+		expectedHeaderValues = append(expectedHeaderValues, cloudFlareStatuses...)
 	}
 
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {

--- a/cdn_resp_headers_test.go
+++ b/cdn_resp_headers_test.go
@@ -73,6 +73,10 @@ func TestRespHeaderAge(t *testing.T) {
 func TestRespHeaderXCacheAppend(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
+	if vendorCloudflare {
+		t.Skip(notSupportedByVendor)
+	}
+
 	const originXCache = "HIT"
 
 	var (
@@ -166,6 +170,10 @@ func TestRespHeaderServedBy(t *testing.T) {
 // This is in the format "{origin-hit-count}, {edge-hit-count}"
 func TestRespHeaderXCacheHitsAppend(t *testing.T) {
 	ResetBackends(backendsByPriority)
+
+	if vendorCloudflare {
+		t.Skip(notSupportedByVendor)
+	}
 
 	const originXCacheHits = "53"
 


### PR DESCRIPTION
Cloudflare's `CF-Cache-Status` header may contain one of the following[1](https://support.cloudflare.com/hc/en-us/articles/200168266-What-do-the-various-CloudFlare-cache-responses-HIT-Expired-etc-mean-):
- HIT
- MISS
- EXPIRED
- STALE
- IGNORED
- REVALIDATED

Add support for `HIT` and `EXPIRED`.

I haven't implemented `STALE`, `IGNORED` or `REVALIDATED` because they only occur under very specific circumstances and so are less useful to us.

Note that I expected to see `IGNORE` rather than `MISS` on an object's first request, as per Cloudflare's documentation, but in reality the `IGNORE` status did not occur in my testing.

---

Also feature-flags the `X-Cache` tests not supported by Cloudflare and tests for a `HIT` status from Fastly's `X-Cache` headers.
