### PR TITLE
Simplify Jenkins script

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,12 +1,4 @@
 #!/bin/sh
-test -z "$TEST_EDGEHOST" && export TEST_EDGEHOST="172.16.20.10"
-if [ "$TEST_VERIFYTLS" = "yes" ]; then
-    export TEST_ARGS="";
-else
-    export TEST_ARGS="-skipVerifyTLS";
-fi
-if [ "$TEST_FAILOVER" = "no" ]; then
-    export TEST_ARGS="${TEST_ARGS} -skipFailover"
-fi
-echo "Running: go test -edgeHost $TEST_EDGEHOST $TEST_ARGS"
-go test -edgeHost $TEST_EDGEHOST $TEST_ARGS
+
+echo "Running: go test ${TEST_ARGS}"
+go test ${TEST_ARGS}


### PR DESCRIPTION
Because we've added more flags recently, it's simpler and more flexible for us to specify all of the command-line arguments in one environment variable (which equates to one text field in the Jenkins job).

Once merged:
- [x] Update Cloudflare Jenkins job
- [x] Update Fastly Jenkins job
