### PR TITLE
[#76769514] Disable TestCacheVary for CloudFlare

### DIFF
--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -86,6 +86,10 @@ func TestCache404Response(t *testing.T) {
 func TestCacheVary(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
+	if vendorCloudflare {
+		t.Skip(notSupportedByVendor)
+	}
+
 	const reqHeaderName = "CustomThing"
 	const respHeaderName = "Reflected-" + reqHeaderName
 	headerVals := []string{


### PR DESCRIPTION
CloudFlare don't currently support HTTP Vary as described by the RFC:
- http://tools.ietf.org/html/rfc7234#section-4.1

They have filed this as a feature request but don't yet have an
implementation date. So for now we'll have to disable this test when
`-vendor cloudflare` is specified.

This isn't ideal but since 513efe3 we do at least have some assurance that
`Accept-Encoding`, which is loosely related, is still working.
