### PR TITLE
TestMiscProtocolRedirect doesn't support fragments

### DIFF
--- a/cdn_misc_test.go
+++ b/cdn_misc_test.go
@@ -29,6 +29,9 @@ func TestMiscProtocolRedirect(t *testing.T) {
 	if len(req.URL.RawQuery) == 0 {
 		t.Fatal("Request must have query params to test preservation")
 	}
+	if req.URL.Fragment != "" {
+		t.Fatal("Request must not have fragment because preservation is not supported")
+	}
 
 	resp := RoundTripCheckError(t, req)
 	defer resp.Body.Close()


### PR DESCRIPTION
Document the fact that none of our vendors preserve URL fragments when
redirecting from HTTP to HTTPS. The same is also true of the bare redirect
that we're about to setup - noticed by Matt. I'm indifferent about whether
this is the _correct_ behaviour.
