### PR TITLE
Go vet fixes

### DIFF
--- a/cdn_misc_test.go
+++ b/cdn_misc_test.go
@@ -46,6 +46,7 @@ func TestMiscProtocolRedirect(t *testing.T) {
 	if dest := resp.Header.Get(headerName); dest != expectedURL {
 		t.Errorf(
 			"Received incorrect %q header. Expected %q, got %q",
+			headerName,
 			expectedURL,
 			dest,
 		)

--- a/cdn_req_headers_test.go
+++ b/cdn_req_headers_test.go
@@ -53,7 +53,7 @@ func TestReqHeaderXFFCreateAndAppend(t *testing.T) {
 	receivedHeaderVals := strings.Split(receivedHeaderVal, ",")
 	if count := len(receivedHeaderVals); count != len(expectedHeaderVals) {
 		t.Fatalf(
-			"Origin received %q header with wrong count of IPs. Expected %d, got %d: %q",
+			"Origin received %q header with wrong count of IPs. Expected %q, got %d: %q",
 			headerName,
 			expectedHeaderVals,
 			count,

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -8,4 +8,6 @@ sudo FACTER_varnish_backend_address="127.0.0.1" \
   mock_cdn_config/manifests/site.pp || [ $? -eq 2 ]
 
 go test -edgeHost 127.0.0.1 -skipVerifyTLS -v -vendor=fastly
+
+go get code.google.com/p/go.tools/cmd/vet
 go vet

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -8,3 +8,4 @@ sudo FACTER_varnish_backend_address="127.0.0.1" \
   mock_cdn_config/manifests/site.pp || [ $? -eq 2 ]
 
 go test -edgeHost 127.0.0.1 -skipVerifyTLS -v -vendor=fastly
+go vet


### PR DESCRIPTION
Fix two errors. Run `go vet` in tests to prevent more.
