### PR TITLE
[#76768770] Cookie/Set-Cookie should be cached

### DIFF
--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -18,7 +18,8 @@ import (
 func TestCacheFirstResponse(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	testRequestsCachedIndefinite(t, nil)
+	req := NewUniqueEdgeGET(t)
+	testRequestsCachedIndefinite(t, req, nil)
 }
 
 // Should cache responses for the period defined in a `Expires: n` response
@@ -33,7 +34,8 @@ func TestCacheExpires(t *testing.T) {
 		w.Header().Set("Expires", headerValue)
 	}
 
-	testRequestsCachedDuration(t, handler, cacheDuration)
+	req := NewUniqueEdgeGET(t)
+	testRequestsCachedDuration(t, req, handler, cacheDuration)
 }
 
 // Should cache responses for the period defined in a `Cache-Control:
@@ -48,7 +50,8 @@ func TestCacheCacheControlMaxAge(t *testing.T) {
 		w.Header().Set("Cache-Control", headerValue)
 	}
 
-	testRequestsCachedDuration(t, handler, cacheDuration)
+	req := NewUniqueEdgeGET(t)
+	testRequestsCachedDuration(t, req, handler, cacheDuration)
 }
 
 // Should cache responses for the period defined in a `Cache-Control:
@@ -68,7 +71,8 @@ func TestCacheExpiresAndMaxAge(t *testing.T) {
 		w.Header().Set("Cache-Control", maxAgeValue)
 	}
 
-	testRequestsCachedDuration(t, handler, cacheDuration)
+	req := NewUniqueEdgeGET(t)
+	testRequestsCachedDuration(t, req, handler, cacheDuration)
 }
 
 // Should cache a response with a `Set-Cookie` and no explicit
@@ -80,7 +84,8 @@ func TestCacheHeaderSetCookie(t *testing.T) {
 		w.Header().Set("Set-Cookie", "sekret=mekmitasdigoat")
 	}
 
-	testRequestsCachedIndefinite(t, handler)
+	req := NewUniqueEdgeGET(t)
+	testRequestsCachedIndefinite(t, req, handler)
 }
 
 // Should cache responses with a status code of 404. It's a common
@@ -93,7 +98,8 @@ func TestCache404Response(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}
 
-	testRequestsCachedIndefinite(t, handler)
+	req := NewUniqueEdgeGET(t)
+	testRequestsCachedIndefinite(t, req, handler)
 }
 
 // Should cache multiple distinct responses for the same URL when origin responds

--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -71,6 +71,18 @@ func TestCacheExpiresAndMaxAge(t *testing.T) {
 	testRequestsCachedDuration(t, handler, cacheDuration)
 }
 
+// Should cache a response with a `Set-Cookie` and no explicit
+// `Cache-Control` headers.
+func TestCacheHeaderSetCookie(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	handler := func(w http.ResponseWriter) {
+		w.Header().Set("Set-Cookie", "sekret=mekmitasdigoat")
+	}
+
+	testRequestsCachedIndefinite(t, handler)
+}
+
 // Should cache responses with a status code of 404. It's a common
 // misconception that 404 responses shouldn't be cached; they should because
 // they can be expensive to generate.

--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -75,6 +75,16 @@ func TestCacheExpiresAndMaxAge(t *testing.T) {
 	testRequestsCachedDuration(t, req, handler, cacheDuration)
 }
 
+// Should cache the response to a request with a `Cookie` header.
+func TestCacheHeaderCookie(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	req := NewUniqueEdgeGET(t)
+	req.Header.Set("Cookie", "sekret=mekmitasdigoat")
+
+	testRequestsCachedIndefinite(t, req, nil)
+}
+
 // Should cache a response with a `Set-Cookie` and no explicit
 // `Cache-Control` headers.
 func TestCacheHeaderSetCookie(t *testing.T) {

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -62,18 +62,6 @@ func TestNoCacheHeaderCookie(t *testing.T) {
 	testThreeRequestsNotCached(t, req, nil)
 }
 
-// Should not cache a response with a `Set-Cookie` header.
-func TestNoCacheHeaderSetCookie(t *testing.T) {
-	ResetBackends(backendsByPriority)
-
-	handler := func(h http.Header) {
-		h.Set("Set-Cookie", "sekret=mekmitasdigoat")
-	}
-
-	req := NewUniqueEdgeGET(t)
-	testThreeRequestsNotCached(t, req, handler)
-}
-
 // Should not cache responses with a `Cache-Control: no-cache` header.
 // Varnish doesn't respect this by default.
 func TestNoCacheCacheControlNoCache(t *testing.T) {

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -52,16 +52,6 @@ func TestNoCacheHeaderAuthorization(t *testing.T) {
 	testThreeRequestsNotCached(t, req, nil)
 }
 
-// Should not cache the response to a request with a `Cookie` header.
-func TestNoCacheHeaderCookie(t *testing.T) {
-	ResetBackends(backendsByPriority)
-
-	req := NewUniqueEdgeGET(t)
-	req.Header.Set("Cookie", "sekret=mekmitasdigoat")
-
-	testThreeRequestsNotCached(t, req, nil)
-}
-
 // Should not cache responses with a `Cache-Control: no-cache` header.
 // Varnish doesn't respect this by default.
 func TestNoCacheCacheControlNoCache(t *testing.T) {

--- a/helpers.go
+++ b/helpers.go
@@ -292,8 +292,12 @@ type responseCallback func(w http.ResponseWriter)
 
 // Wrapper for testRequestsCachedDuration() with a respTTL of zero.
 // Meaning that the cached object doesn't expire.
-func testRequestsCachedIndefinite(t *testing.T, respCB responseCallback) {
-	testRequestsCachedDuration(t, respCB, time.Duration(0))
+func testRequestsCachedIndefinite(
+	t *testing.T,
+	req *http.Request,
+	respCB responseCallback,
+) {
+	testRequestsCachedDuration(t, req, respCB, time.Duration(0))
 }
 
 // Helper function to make three requests and test responses. If respTTL is:
@@ -307,7 +311,12 @@ func testRequestsCachedIndefinite(t *testing.T, respCB responseCallback) {
 //
 // A responseCallback, if not nil, will be called to modify the response
 // before calling Write(body).
-func testRequestsCachedDuration(t *testing.T, respCB responseCallback, respTTL time.Duration) {
+func testRequestsCachedDuration(
+	t *testing.T,
+	req *http.Request,
+	respCB responseCallback,
+	respTTL time.Duration,
+) {
 	const responseCached = "first response"
 	const responseNotCached = "subsequent response"
 	var testCacheExpiry bool = respTTL > 0
@@ -321,9 +330,6 @@ func testRequestsCachedDuration(t *testing.T, respCB responseCallback, respTTL t
 	case false:
 		requestsExpectedCount = 1
 	}
-
-	url := fmt.Sprintf("https://%s/%s", *edgeHost, NewUUID())
-	req, _ := http.NewRequest("GET", url, nil)
 
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {
 		if respCB != nil {

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -76,6 +76,10 @@ sub vcl_recv {
   }
 
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  if (req.http.Cookie) {
+    return (lookup);
+  }
 }
 
 sub vcl_fetch {

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -95,6 +95,10 @@ sub vcl_fetch {
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (hit_for_pass);
   }
+
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
 }
 
 sub vcl_deliver {


### PR DESCRIPTION
#### Set-Cookie responses should be cached

Move this test from TestNoCache to TestCache. The RFC states:
http://tools.ietf.org/html/rfc7234#section-8

> Note that the Set-Cookie response header field [RFC6265] does not
> inhibit caching; a cacheable response with a Set-Cookie header field
> can be (and often is) used to satisfy subsequent requests to caches.
> Servers who wish to control caching of these responses are encouraged
> to emit appropriate Cache-Control response header fields.

This passes on CloudFlare. We'll need to modify our Fastly configs to remove
a section of config that we copied from the UI-generated config.
#### Cookie requests should be cached

Move this test from TestNoCache to TestCache. Most sites set cookies, either
by Set-Cookie responses from origin or client-side javascript, and they will
provide a Cookie header in each request. If we weren't to cache these then
nearly all traffic would hit origin. This matches the default behaviour of
Fastly and CloudFlare.
