### PR TITLE
[Fixes #76768770] Move Authorization from NoCache to Cache

### DIFF
--- a/cdn_cache_test.go
+++ b/cdn_cache_test.go
@@ -134,6 +134,19 @@ func TestCacheHeaderSetCookie(t *testing.T) {
 	testRequestsCachedIndefinite(t, req, handler)
 }
 
+// Should cache the response to a request with a `Authorization` header.
+// This tests documents actual behaviour; even though it appears to
+// contravene RFC 7234 section 3.2:
+// http://tools.ietf.org/html/rfc7234#section-3.2
+func TestCacheHeaderAuthorization(t *testing.T) {
+	ResetBackends(backendsByPriority)
+
+	req := NewUniqueEdgeGET(t)
+	req.Header.Set("Authorization", "Basic YXJlbnR5b3U6aW5xdWlzaXRpdmU=")
+
+	testRequestsCachedIndefinite(t, req, nil)
+}
+
 // Should cache responses with a status code of 404. It's a common
 // misconception that 404 responses shouldn't be cached; they should because
 // they can be expensive to generate.

--- a/cdn_nocache_test.go
+++ b/cdn_nocache_test.go
@@ -42,16 +42,6 @@ func TestNoCachePOST(t *testing.T) {
 	testThreeRequestsNotCached(t, req, nil)
 }
 
-// Should not cache the response to a request with a `Authorization` header.
-func TestNoCacheHeaderAuthorization(t *testing.T) {
-	ResetBackends(backendsByPriority)
-
-	req := NewUniqueEdgeGET(t)
-	req.Header.Set("Authorization", "Basic YXJlbnR5b3U6aW5xdWlzaXRpdmU=")
-
-	testThreeRequestsNotCached(t, req, nil)
-}
-
 // Should not cache responses with a `Cache-Control: no-cache` header.
 // Varnish doesn't respect this by default.
 func TestNoCacheCacheControlNoCache(t *testing.T) {

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -88,7 +88,7 @@ sub vcl_recv {
 
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
-  if (req.http.Cookie) {
+  if (req.http.Cookie || req.http.Authorization) {
     return (lookup);
   }
 }


### PR DESCRIPTION
Despite what the RFC says, all of our current vendors _do_ cache requests
that have Authorization headers and no explicit Cache-Control headers in the
response. They are not sure why - but we've lived with this behaviour for
some time now and are happy to accept it.
