### PR TITLE
Improve TestNoManipulation*

### DIFF
--- a/cdn_nomanipulate_test.go
+++ b/cdn_nomanipulate_test.go
@@ -13,58 +13,40 @@ import (
 func TestNoManipulationHTML(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const fixtureFile = "fixtures/golang.html"
-	const contentType = "text/html; charset=utf-8"
-
-	testResponseNotManipulated(t, fixtureFile, contentType)
+	testResponseNotManipulated(t, "fixtures/golang.html")
 }
 
 // Should not manipulate CSS content in response bodies.
 func TestNoManipulationCSS(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const fixtureFile = "fixtures/golang.css"
-	const contentType = "text/css; charset=utf-8"
-
-	testResponseNotManipulated(t, fixtureFile, contentType)
+	testResponseNotManipulated(t, "fixtures/golang.css")
 }
 
 // Should not manipulate Javascript content in response bodies.
 func TestNoManipulationJS(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const fixtureFile = "fixtures/golang.js"
-	const contentType = "application/x-javascript"
-
-	testResponseNotManipulated(t, fixtureFile, contentType)
+	testResponseNotManipulated(t, "fixtures/golang.js")
 }
 
 // Should not manipulate PNG images in response bodies.
 func TestNoManipulationPNG(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const fixtureFile = "fixtures/golang.png"
-	const contentType = "image/png"
-
-	testResponseNotManipulated(t, fixtureFile, contentType)
+	testResponseNotManipulated(t, "fixtures/golang.png")
 }
 
 // Should not manipulate JPEG images in response bodies.
 func TestNoManipulationJPEG(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const fixtureFile = "fixtures/golang.jpeg"
-	const contentType = "image/jpeg"
-
-	testResponseNotManipulated(t, fixtureFile, contentType)
+	testResponseNotManipulated(t, "fixtures/golang.jpeg")
 }
 
 // Should not manipulate GIF images in response bodies.
 func TestNoManipulationGIF(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
-	const fixtureFile = "fixtures/golang.gif"
-	const contentType = "image/gif"
-
-	testResponseNotManipulated(t, fixtureFile, contentType)
+	testResponseNotManipulated(t, "fixtures/golang.gif")
 }

--- a/helpers.go
+++ b/helpers.go
@@ -433,8 +433,9 @@ func testThreeRequestsNotCached(t *testing.T, req *http.Request, headerCB respon
 // testResponseNotManipulated configures origin to respond to a request with
 // the contents of fixture file. It then makes a request and asserts that
 // the response body matches the original fixture file, meaning that the CDN
-// hasn't manipulated it in any way. The `Content-Type` is set according to
-// the fixture's file extension to ensure that the CDN detects it correctly.
+// hasn't manipulated it in any way. The `Content-Type` and request path are
+// set according to the fixture's file extension to ensure that the CDN
+// detects it correctly.
 func testResponseNotManipulated(t *testing.T, fixtureFile string) {
 	fixtureData, err := ioutil.ReadFile(fixtureFile)
 	if err != nil {
@@ -452,6 +453,8 @@ func testResponseNotManipulated(t *testing.T, fixtureFile string) {
 	})
 
 	req := NewUniqueEdgeGET(t)
+	req.URL.Path = "/" + filepath.Base(fixtureFile)
+
 	resp := RoundTripCheckError(t, req)
 	defer resp.Body.Close()
 

--- a/helpers.go
+++ b/helpers.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -428,13 +431,19 @@ func testThreeRequestsNotCached(t *testing.T, req *http.Request, headerCB respon
 }
 
 // testResponseNotManipulated configures origin to respond to a request with
-// the contents of fixture file and a given `Content-Type`. It then makes a
-// request and asserts that the response body matches the original fixture
-// file, meaning that the CDN hasn't manipulated it in any way.
-func testResponseNotManipulated(t *testing.T, fixtureFile string, contentType string) {
+// the contents of fixture file. It then makes a request and asserts that
+// the response body matches the original fixture file, meaning that the CDN
+// hasn't manipulated it in any way. The `Content-Type` is set according to
+// the fixture's file extension to ensure that the CDN detects it correctly.
+func testResponseNotManipulated(t *testing.T, fixtureFile string) {
 	fixtureData, err := ioutil.ReadFile(fixtureFile)
 	if err != nil {
 		t.Fatalf("Unable load fixture file %q", fixtureFile)
+	}
+
+	contentType := mime.TypeByExtension(filepath.Ext(fixtureFile))
+	if contentType == "" || strings.Contains(contentType, "text/plain") {
+		t.Fatalf("Unable to determine fixture Content-Type. Got %q", contentType)
 	}
 
 	originServer.SwitchHandler(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Use mime.TypeByExtension for fixture Content-Type

DRYs up the tests significantly. This doesn't suffer from the same problems
as http.DetectContentType described in 40048ca whereby it would detect JS
and CSS as generic `text/plain`.

The builtin map works sufficiently on OS X which doesn't have
`/etc/mime.types` to supplement it. Although, just to be safe, I have added
an additional check to make sure that we don't get an empty or generic type.

Thanks to @mattbostock for indirectly finding this.
#### Set req.URL.Path in testResponseNotManipulated

To give the CDN some additional help in determining the type. The
`Content-Type` header should be sufficient, but we can't get the image tests
to fail on CloudFlare when the right boxes are ticked and we've noticed that
they sometimes care more about file extensions than content.

This won't affect the random UUID that forms part of the request as a query
param because they exist in a different `req.URL` field.
