### PR TITLE
Remove vendor switch for True-Client-IP

### DIFF
--- a/cdn_req_headers_test.go
+++ b/cdn_req_headers_test.go
@@ -76,20 +76,14 @@ func TestReqHeaderXFFCreateAndAppend(t *testing.T) {
 }
 
 // Should create a True-Client-IP header containing the client's IP
-// address, discarding the value provided in the original request.
+// address, discarding the value provided in the original request. The name
+// of this header must be consistent across all vendors.
 func TestReqHeaderUnspoofableClientIP(t *testing.T) {
 	ResetBackends(backendsByPriority)
 
 	const sentHeaderVal = "203.0.113.99"
-	var headerName string
+	const headerName = "True-Client-IP"
 	var receivedHeaderVal string
-
-	switch {
-	case vendorCloudflare, vendorFastly:
-		headerName = "True-Client-IP"
-	default:
-		t.Fatal(notImplementedForVendor)
-	}
 
 	sentHeaderIP := net.ParseIP(sentHeaderVal)
 


### PR DESCRIPTION
This is now implemented by both of our providers, so we no longer need to
switch on the vendor flag.

Include a comment in the test description that this needs to be consistent
across all vendors. Too long for the comment - but this is because if we
accepted two values and tested them in order, then it would be possible to
spoof one of them.
