### PR TITLE
Change expected body text to match new error page

### DIFF
--- a/cdn_failover_test.go
+++ b/cdn_failover_test.go
@@ -28,7 +28,7 @@ func TestFailoverErrorPageAllServersDown(t *testing.T) {
 
 	switch {
 	case vendorFastly:
-		expectedBody = "Guru Mediation"
+		expectedBody = "Sorry! We're having issues right now. Please try again later."
 	default:
 		expectedBody = "Guru Meditation"
 	}

--- a/mock_cdn_config/modules/varnish/templates/default.vcl.erb
+++ b/mock_cdn_config/modules/varnish/templates/default.vcl.erb
@@ -164,24 +164,18 @@ sub vcl_error {
      return (deliver);
   }
 
-  # Supply a built-in error page with an intentional typo;
-  # 'Guru Mediation' (sic) to match Fastly's error page
+  # Supply a custom error page which is loaded into the CDN
+  # provider and used if every other backend is unavailable.
   set obj.http.Content-Type = "text/html; charset=utf-8";
   synthetic {"
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
- "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html>
   <head>
-    <title>"} + obj.status + " " + obj.response + {"</title>
+    <title>Custom synthetic error page</title>
   </head>
   <body>
-    <h1>Error "} + obj.status + " " + obj.response + {"</h1>
-    <p>"} + obj.response + {"</p>
-    <h3>Guru Mediation:</h3>
-    <p>XID: "} + req.xid + {"</p>
-    <hr>
-    <p>Varnish cache server</p>
+    <h1>Custom synthetic error page</h1>
+    <p>Sorry! We're having issues right now. Please try again later.</p>
   </body>
 </html>
 "};


### PR DESCRIPTION
We want to display a custom synthetic HTML page from the CDN when the origin and both sets of mirrors are down, rather than the standard "Guru Mediation/Meditation" page.

This commit pulls in some text from that page that we can assert with and updates the mock Varnish config to reflect the change.
