### PR TITLE
[#58334980] Consider all HEAD requests to be probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ To see all available command-line options:
 go test -usage
 ```
 
+## Adapting the tests to your own configuration
+
+You may need to make some changes to adapt the tests to your specific configuration.
+
+- The tests [disregard all `HEAD`
+  requests](https://github.com/alphagov/cdn-acceptance-tests/blob/f4ad7291ad2f49c549567664d7e4355b2dfc43e4/helpers.go#L37-L40)
+  as healthcheck probes. You may need to modify this or filter those on other
+  HTTP request headers depending on how your edge sends healthcheck probes.
+
 ## Writing tests
 
 When writing new tests please be sure to:

--- a/helpers.go
+++ b/helpers.go
@@ -30,11 +30,13 @@ type CDNBackendServer struct {
 }
 
 // ServeHTTP satisfies the http.HandlerFunc interface. Health check requests
-// for `HEAD /` are always served 200 responses. Other requests are passed
+// for `HEAD` are always served 200 responses. Other requests are passed
 // off to a custom handler provided by SwitchHandler.
 func (s *CDNBackendServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Backend-Name", s.Name)
-	if r.Method == "HEAD" && r.URL.Path == "/" {
+
+        // swallow healtheck requests
+	if r.Method == "HEAD" {
 		w.Header().Set("PING", "PONG")
 		return
 	}


### PR DESCRIPTION
Consider all HTTP HEAD requests to be backend probes.

We treat backend healthcheck probes (originating from the CDN)
differently to normal requests as they could skew our test results.

Any HEAD request for the `/` path was considered as a probe.

When testing a new VCL configuration, we needed to use a probe endpoint
other than `/` (that endpoint returns a 404 for this particular
service).

So relax the check such that any `HEAD` HTTP requests are considered to
be probes. We don't have any acceptance tests specific to HEAD requests
currently.
